### PR TITLE
Added option to set multiple roots to compileSchema

### DIFF
--- a/src/domains/field/compiler/services.ts
+++ b/src/domains/field/compiler/services.ts
@@ -3,7 +3,7 @@ import { FieldError } from '../index';
 
 import { resolveTypeOrThrow, inferTypeOrThrow } from './fieldType';
 import {
-  schemaRegistry,
+  schemaRootsRegistry,
   mutationFieldsRegistry,
   queryFieldsRegistry,
 } from 'domains/schema';
@@ -43,7 +43,7 @@ export function enhanceType(originalType: GraphQLOutputType, isNullable: boolean
 }
 
 export function isRootFieldOnNonRootBase(base: Function, fieldName: string) {
-  const isRoot = schemaRegistry.has(base);
+  const isRoot = schemaRootsRegistry.has(base);
   if (isRoot) {
     return false;
   }

--- a/src/domains/index.ts
+++ b/src/domains/index.ts
@@ -11,4 +11,10 @@ export { Inject, Context, Source, Info } from './inject';
 export { registerEnum, enumsRegistry } from './enum';
 export { Union, unionRegistry } from './union';
 export { Before, After } from './hooks';
-export { Schema, schemaRegistry, compileSchema, Query, Mutation } from './schema';
+export {
+  SchemaRoot,
+  schemaRootsRegistry,
+  compileSchema,
+  Query,
+  Mutation,
+} from './schema';

--- a/src/domains/index.ts
+++ b/src/domains/index.ts
@@ -13,6 +13,7 @@ export { Union, unionRegistry } from './union';
 export { Before, After } from './hooks';
 export {
   SchemaRoot,
+  Schema,
   schemaRootsRegistry,
   compileSchema,
   Query,

--- a/src/domains/schema/compiler.ts
+++ b/src/domains/schema/compiler.ts
@@ -5,54 +5,43 @@ import {
   GraphQLOutputType,
   isOutputType,
 } from 'graphql';
-import { queryFieldsRegistry, mutationFieldsRegistry, schemaRegistry } from './registry';
+import {
+  queryFieldsRegistry,
+  mutationFieldsRegistry,
+  schemaRootsRegistry,
+  RootFieldsRegistry,
+} from './registry';
 import { SchemaError } from './error';
-import { mapObject } from 'services/utils';
+import { mapObject, showDeprecationWarning } from 'services/utils';
 
-function validateSchemaTarget(target: Function) {
-  if (!schemaRegistry.has(target)) {
-    throw new SchemaError(target, `Schema target must be registered with @Schema`);
-  }
-
-  if (queryFieldsRegistry.isEmpty(target)) {
-    throw new SchemaError(
-      target,
-      `Schema must have at least one field registered with @Query`,
-    );
+function validateSchemaRoots(roots: Function[]) {
+  for (let root of roots) {
+    if (!schemaRootsRegistry.has(root)) {
+      throw new SchemaError(root, `Schema root must be registered with @SchemaRoot`);
+    }
   }
 }
 
-function validateRootFieldType(
-  target: Function,
-  fieldName: string,
-  type: GraphQLOutputType,
-  rootFieldType: string,
-) {
-  // return true;
-  if (!isOutputType(type)) {
-    throw new SchemaError(
-      target,
-      `Root field ${rootFieldType}.${fieldName} is not compiled to GraphQLOutputType. Compiled type is '${type}'.`,
-    );
+interface CompileSchemaOptions {
+  roots: Function[];
+}
+
+function getAllRootFieldsFromRegistry(
+  roots: Function[],
+  registry: RootFieldsRegistry,
+  name: 'Query' | 'Mutation',
+): GraphQLObjectType {
+  const allQueryFields: { [key: string]: GraphQLFieldConfig<any, any> } = {};
+  for (let root of roots) {
+    const rootFields = registry.getAll(root);
+    Object.keys(rootFields).forEach(fieldName => {
+      const fieldConfigGetter = rootFields[fieldName];
+      const fieldConfig = fieldConfigGetter();
+      allQueryFields[fieldName] = fieldConfig;
+    });
   }
-}
 
-interface FieldsData {
-  [fieldName: string]: () => GraphQLFieldConfig<any, any>;
-}
-
-function compileSchemaRootFieldIfNotEmpty(
-  target: Function,
-  name: string,
-  fields: FieldsData,
-) {
-  const compiledFields = mapObject(fields, (compiler, fieldName) => {
-    const compiledField = compiler();
-    validateRootFieldType(target, fieldName, compiledField.type, name);
-    return compiledField;
-  });
-
-  const isEmpty = Object.keys(compiledFields).length <= 0;
+  const isEmpty = Object.keys(allQueryFields).length < 1;
 
   if (isEmpty) {
     return null;
@@ -60,24 +49,33 @@ function compileSchemaRootFieldIfNotEmpty(
 
   return new GraphQLObjectType({
     name,
-    fields: compiledFields,
+    fields: allQueryFields,
   });
 }
 
-export function compileSchema(target: Function) {
-  const query = compileSchemaRootFieldIfNotEmpty(
-    target,
-    'Query',
-    queryFieldsRegistry.getAll(target),
-  );
+export function compileSchema(config: CompileSchemaOptions | Function) {
+  const roots = typeof config === 'function' ? [config] : config.roots;
 
-  const mutation = compileSchemaRootFieldIfNotEmpty(
-    target,
+  if (typeof config === 'function') {
+    console.warn(``);
+    showDeprecationWarning(
+      `Passing schema root to compileSchema is deprecated. Use config object with 'roots' field. compileSchema(SchemaRoot) --> compileSchema({ roots: [SchemaRoot] })`,
+      config,
+    );
+  }
+
+  validateSchemaRoots(roots);
+
+  const query = getAllRootFieldsFromRegistry(roots, queryFieldsRegistry, 'Query');
+  const mutation = getAllRootFieldsFromRegistry(
+    roots,
+    mutationFieldsRegistry,
     'Mutation',
-    mutationFieldsRegistry.getAll(target),
   );
 
-  validateSchemaTarget(target);
+  if (!query) {
+    throw new Error('At least one of schema roots must have at least one @Query field.');
+  }
 
   return new GraphQLSchema({
     query: query || undefined,

--- a/src/domains/schema/error.ts
+++ b/src/domains/schema/error.ts
@@ -1,6 +1,6 @@
 import { BaseError } from 'services/error';
 
-export class SchemaError extends BaseError {
+export class SchemaRootError extends BaseError {
   constructor(target: Function, msg: string) {
     const fullMsg = `@Schema ${target.name}: ${msg}`;
     super(fullMsg);

--- a/src/domains/schema/index.ts
+++ b/src/domains/schema/index.ts
@@ -1,12 +1,15 @@
-export { schemaRegistry, mutationFieldsRegistry, queryFieldsRegistry } from './registry';
-import { schemaRegistry } from './registry';
-import { compileSchema } from './compiler';
+export {
+  schemaRootsRegistry,
+  mutationFieldsRegistry,
+  queryFieldsRegistry,
+} from './registry';
+import { schemaRootsRegistry, SchemaRootConfig } from './registry';
+// import { compileSchema } from './compiler';
 export { compileSchema } from './compiler';
 export { Query, Mutation } from './rootFields';
 
-export function Schema(): ClassDecorator {
+export function SchemaRoot(config: SchemaRootConfig = {}): ClassDecorator {
   return target => {
-    const compiler = () => compileSchema(target);
-    schemaRegistry.set(target, compiler);
+    schemaRootsRegistry.set(target, config);
   };
 }

--- a/src/domains/schema/index.ts
+++ b/src/domains/schema/index.ts
@@ -4,6 +4,7 @@ export {
   queryFieldsRegistry,
 } from './registry';
 import { schemaRootsRegistry, SchemaRootConfig } from './registry';
+import { showDeprecationWarning } from 'services/utils';
 // import { compileSchema } from './compiler';
 export { compileSchema } from './compiler';
 export { Query, Mutation } from './rootFields';
@@ -12,4 +13,12 @@ export function SchemaRoot(config: SchemaRootConfig = {}): ClassDecorator {
   return target => {
     schemaRootsRegistry.set(target, config);
   };
+}
+
+export function Schema(config: SchemaRootConfig = {}) {
+  showDeprecationWarning(
+    'Use @SchemaRoot instead and compile like: compileSchema({ roots: [RootA, RootB] })',
+    Schema,
+  );
+  return SchemaRoot(config);
 }

--- a/src/domains/schema/registry.ts
+++ b/src/domains/schema/registry.ts
@@ -1,4 +1,4 @@
-import { GraphQLSchema, GraphQLFieldConfig } from 'graphql';
+import { GraphQLFieldConfig } from 'graphql';
 import { DeepWeakMap } from 'services/utils';
 
 type Getter<Result> = () => Result;

--- a/src/domains/schema/registry.ts
+++ b/src/domains/schema/registry.ts
@@ -3,7 +3,14 @@ import { DeepWeakMap } from 'services/utils';
 
 type Getter<Result> = () => Result;
 
-export const schemaRegistry = new WeakMap<Function, Getter<GraphQLSchema>>();
+export interface SchemaRootConfig {}
+
+export const schemaRootsRegistry = new WeakMap<Function, SchemaRootConfig>();
+
+export type RootFieldsRegistry = DeepWeakMap<
+  Function,
+  Getter<GraphQLFieldConfig<any, any>>
+>;
 
 export const queryFieldsRegistry = new DeepWeakMap<
   Function,

--- a/src/domains/schema/rootFields.ts
+++ b/src/domains/schema/rootFields.ts
@@ -1,5 +1,9 @@
 import { Field, FieldOptions, compileFieldConfig } from 'domains/field';
-import { queryFieldsRegistry, mutationFieldsRegistry, schemaRegistry } from './registry';
+import {
+  queryFieldsRegistry,
+  mutationFieldsRegistry,
+  schemaRootsRegistry,
+} from './registry';
 import { SchemaFieldError } from './error';
 
 function validateRootSchemaField(targetInstance: Object, fieldName: string) {
@@ -16,7 +20,7 @@ function validateRootSchemaField(targetInstance: Object, fieldName: string) {
 }
 
 function requireSchemaRoot(target: Function, fieldName: string) {
-  if (schemaRegistry.has(target)) {
+  if (schemaRootsRegistry.has(target)) {
     return;
   }
   throw new SchemaFieldError(

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export {
   Arg,
   Field,
   Info,
-  Schema,
+  SchemaRoot,
   Context,
   ObjectType,
   Query,

--- a/src/services/utils/deprecation/index.ts
+++ b/src/services/utils/deprecation/index.ts
@@ -1,6 +1,10 @@
 const shownRegistry = new WeakMap<any, true>();
 
-export function showDeprecationWarning(message: string, uniqueIdentifier?: any) {
+export function showDeprecationWarning(
+  message: string,
+  uniqueIdentifier?: any,
+  callback?: (message: string) => void,
+) {
   if (uniqueIdentifier && shownRegistry.has(uniqueIdentifier)) {
     return;
   }
@@ -8,4 +12,7 @@ export function showDeprecationWarning(message: string, uniqueIdentifier?: any) 
     shownRegistry.set(uniqueIdentifier, true);
   }
   console.warn(`@Deprecation warning: ${message}`);
+  if (callback) {
+    callback(message);
+  }
 }

--- a/src/services/utils/deprecation/index.ts
+++ b/src/services/utils/deprecation/index.ts
@@ -1,0 +1,11 @@
+const shownRegistry = new WeakMap<any, true>();
+
+export function showDeprecationWarning(message: string, uniqueIdentifier?: any) {
+  if (uniqueIdentifier && shownRegistry.has(uniqueIdentifier)) {
+    return;
+  }
+  if (uniqueIdentifier) {
+    shownRegistry.set(uniqueIdentifier, true);
+  }
+  console.warn(`@Deprecation warning: ${message}`);
+}

--- a/src/services/utils/index.ts
+++ b/src/services/utils/index.ts
@@ -10,3 +10,5 @@ export {
   resolveTypesList,
   isObjectType,
 } from './gql';
+
+export { showDeprecationWarning } from './deprecation';

--- a/src/test/functional/enum.spec.ts
+++ b/src/test/functional/enum.spec.ts
@@ -1,6 +1,6 @@
 import {
   Query,
-  Schema,
+  SchemaRoot,
   compileSchema,
   ObjectType,
   Arg,
@@ -28,7 +28,7 @@ class Hello {
   }
 }
 
-@Schema()
+@SchemaRoot()
 class FooSchema {
   @Query()
   hello(): Hello {
@@ -36,7 +36,7 @@ class FooSchema {
   }
 }
 
-const schema = compileSchema(FooSchema);
+const schema = compileSchema({ roots: [FooSchema] });
 
 describe('Query with enums', () => {
   it('Will guard proper enum values', async () => {

--- a/src/test/functional/mutation.spec.ts
+++ b/src/test/functional/mutation.spec.ts
@@ -1,6 +1,6 @@
 import {
   Query,
-  Schema,
+  SchemaRoot,
   compileSchema,
   ObjectType,
   Field,
@@ -24,7 +24,7 @@ class Hello {
   }
 }
 
-@Schema()
+@SchemaRoot()
 class FooSchema {
   @Mutation()
   hello(): Hello {
@@ -37,7 +37,7 @@ class FooSchema {
   }
 }
 
-const schema = compileSchema(FooSchema);
+const schema = compileSchema({ roots: [FooSchema] });
 
 describe('Mutation', () => {
   it('should not allow wrong argument types', async () => {

--- a/src/test/functional/query.spec.ts
+++ b/src/test/functional/query.spec.ts
@@ -1,4 +1,4 @@
-import { Query, Schema, compileSchema, ObjectType, Field } from 'domains';
+import { Query, SchemaRoot, compileSchema, ObjectType, Field } from 'domains';
 import { graphql } from 'graphql';
 
 @ObjectType()
@@ -9,7 +9,7 @@ class Hello {
   }
 }
 
-@Schema()
+@SchemaRoot()
 class FooSchema {
   @Query()
   hello(): Hello {
@@ -22,7 +22,7 @@ class FooSchema {
   }
 }
 
-const schema = compileSchema(FooSchema);
+const schema = compileSchema({ roots: [FooSchema] });
 
 describe('Query', () => {
   it('should support queries with simple arguments', async () => {

--- a/src/test/misc/index.spec.ts
+++ b/src/test/misc/index.spec.ts
@@ -1,0 +1,12 @@
+import { showDeprecationWarning } from 'services/utils';
+
+describe('showDeprecationWarning', () => {
+  it('Will not show deprecation warning twice for the same object', async () => {
+    const object = {};
+    const watcher = jest.fn();
+    showDeprecationWarning('Test', object, watcher);
+    showDeprecationWarning('Test', object, watcher);
+
+    expect(watcher).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/test/schema/__snapshots__/index.spec.ts.snap
+++ b/src/test/schema/__snapshots__/index.spec.ts.snap
@@ -1011,8 +1011,10 @@ In some cases, you need to provide options to alter GraphQL's execution behavior
 }
 `;
 
-exports[`@SchemaRoot should not allow @Schema without any @Query field 1`] = `"At least one of schema roots must have at least one @Query field."`;
+exports[`@SchemaRoot should not allow @Schema without any @Query field 1`] = `"At least one of schema roots must have @Query root field."`;
 
 exports[`@SchemaRoot should not allow compiling schema not decorated with @Schema 1`] = `"@Schema Foo: Schema root must be registered with @SchemaRoot"`;
 
-exports[`@SchemaRoot should not allow schema that has only mutation fields 1`] = `"At least one of schema roots must have at least one @Query field."`;
+exports[`@SchemaRoot should not allow schema that has only mutation fields 1`] = `"At least one of schema roots must have @Query root field."`;
+
+exports[`@SchemaRoot will not allow multiple schema roots to have conflicting root field names 1`] = `"@Schema BarSchema: Duplicate of root field name: 'foo'. Seems this name is also used inside other schema root."`;

--- a/src/test/schema/__snapshots__/index.spec.ts.snap
+++ b/src/test/schema/__snapshots__/index.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`@Schema should generate all schema fields properly for valid schema 1`] = `
+exports[`@SchemaRoot should generate all schema fields properly for valid schema 1`] = `
 Object {
   "data": Object {
     "__schema": Object {
@@ -1011,6 +1011,8 @@ In some cases, you need to provide options to alter GraphQL's execution behavior
 }
 `;
 
-exports[`@Schema should not allow @Schema without any @Query field 1`] = `"@Schema Foo: Schema must have at least one field registered with @Query"`;
+exports[`@SchemaRoot should not allow @Schema without any @Query field 1`] = `"At least one of schema roots must have at least one @Query field."`;
 
-exports[`@Schema should not allow compiling schema not decorated with @Schema 1`] = `"@Schema Foo: Schema target must be registered with @Schema"`;
+exports[`@SchemaRoot should not allow compiling schema not decorated with @Schema 1`] = `"@Schema Foo: Schema root must be registered with @SchemaRoot"`;
+
+exports[`@SchemaRoot should not allow schema that has only mutation fields 1`] = `"At least one of schema roots must have at least one @Query field."`;

--- a/src/test/schema/index.spec.ts
+++ b/src/test/schema/index.spec.ts
@@ -126,4 +126,26 @@ describe('@SchemaRoot', () => {
       compileSchema({ roots: [FooSchema, BarSchema] }),
     ).toThrowErrorMatchingSnapshot();
   });
+
+  it('will not allow multiple schema roots to have conflicting root field names', async () => {
+    @SchemaRoot()
+    class FooSchema {
+      @Query()
+      foo(): string {
+        return 'foo';
+      }
+    }
+
+    @SchemaRoot()
+    class BarSchema {
+      @Query()
+      foo(): number {
+        return 42;
+      }
+    }
+
+    expect(() =>
+      compileSchema({ roots: [FooSchema, BarSchema] }),
+    ).toThrowErrorMatchingSnapshot();
+  });
 });

--- a/src/test/schema/index.spec.ts
+++ b/src/test/schema/index.spec.ts
@@ -1,18 +1,24 @@
-import { Query, Schema, compileSchema, ObjectType, Field } from 'domains';
-import { graphql, introspectionQuery } from 'graphql';
+import { Query, SchemaRoot, compileSchema, ObjectType, Field, Mutation } from 'domains';
+import {
+  graphql,
+  introspectionQuery,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLFloat,
+} from 'graphql';
 
-describe('@Schema', () => {
+describe('@SchemaRoot', () => {
   it('should not allow compiling schema not decorated with @Schema', () => {
     class Foo {}
 
-    expect(() => compileSchema(Foo)).toThrowErrorMatchingSnapshot();
+    expect(() => compileSchema({ roots: [Foo] })).toThrowErrorMatchingSnapshot();
   });
 
   it('should not allow @Schema without any @Query field', () => {
-    @Schema()
+    @SchemaRoot()
     class Foo {}
 
-    expect(() => compileSchema(Foo)).toThrowErrorMatchingSnapshot();
+    expect(() => compileSchema({ roots: [Foo] })).toThrowErrorMatchingSnapshot();
   });
 
   it('should generate all schema fields properly for valid schema', async () => {
@@ -24,7 +30,7 @@ describe('@Schema', () => {
       }
     }
 
-    @Schema()
+    @SchemaRoot()
     class FooSchema {
       @Query()
       hello(): Hello {
@@ -32,8 +38,92 @@ describe('@Schema', () => {
       }
     }
 
-    const schema = compileSchema(FooSchema);
+    const schema = compileSchema({ roots: [FooSchema] });
 
     expect(await graphql(schema, introspectionQuery)).toMatchSnapshot();
+  });
+
+  it('should allow schema to be compiled from multiple roots', async () => {
+    @SchemaRoot()
+    class FooSchema {
+      @Query()
+      foo(): string {
+        return 'foo';
+      }
+    }
+
+    @SchemaRoot()
+    class BarSchema {
+      @Query()
+      bar(): number {
+        return 42;
+      }
+    }
+
+    const schema = compileSchema({ roots: [FooSchema, BarSchema] });
+
+    const queryType = schema.getQueryType() as GraphQLObjectType;
+
+    const { foo, bar } = queryType.getFields();
+
+    expect(foo.name).toEqual('foo');
+    expect(foo.type).toEqual(GraphQLString);
+
+    expect(bar.name).toEqual('bar');
+    expect(bar.type).toEqual(GraphQLFloat);
+  });
+
+  it('should allow schema root with mutations only if there is other root with queries', async () => {
+    @SchemaRoot()
+    class FooSchema {
+      @Query()
+      foo(): string {
+        return 'foo';
+      }
+    }
+
+    @SchemaRoot()
+    class BarSchema {
+      @Mutation()
+      bar(): number {
+        return 42;
+      }
+    }
+
+    const schema = compileSchema({ roots: [FooSchema, BarSchema] });
+
+    const queryType = schema.getQueryType() as GraphQLObjectType;
+    const mutationType = schema.getMutationType() as GraphQLObjectType;
+
+    const { foo } = queryType.getFields();
+    const { bar } = mutationType.getFields();
+
+    expect(foo.name).toEqual('foo');
+    expect(foo.type).toEqual(GraphQLString);
+
+    expect(bar.name).toEqual('bar');
+    expect(bar.type).toEqual(GraphQLFloat);
+  });
+
+  it('should not allow schema that has only mutation fields', async () => {
+    @SchemaRoot()
+    class FooSchema {
+      @Mutation()
+      foo(): string {
+        return 'foo';
+      }
+    }
+
+    @SchemaRoot()
+    class BarSchema {
+      @Mutation()
+      bar(): number {
+        return 42;
+      }
+    }
+
+    expect(() =>
+      compileSchema({ roots: [FooSchema, BarSchema] }),
+    ).toThrowErrorMatchingSnapshot();
   });
 });


### PR DESCRIPTION
This branch allows adding multiple roots to `compileSchema` allowing things like: 

```ts
@SchemaRoot()
class FooSchema {
  @Query()
  foo(): string {
    return 'foo';
  }
}

@SchemaRoot()
class BarSchema {
  @Mutation()
  bar(): number {
    return 42;
  }
}

const schema = compileSchema({ roots: [FooSchema, BarSchema] });
```

It's still allowing creating schema 'old way' with `compileSchema(SchemaClass);` but it'll show deprecation warning.