### PR TITLE
Fix type declerations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ _book
 
 coverage
 yarn-error.log
+.vscode

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   modulePaths: ['<rootDir>/src/'],
+  moduleNameMapper:{
+	  '~/(.*)':'<rootDir>/src/$1'
+  },  
   moduleFileExtensions: ['ts', 'tsx', 'js'],
   transform: {
     '^.+\\.(ts|tsx)$': '<rootDir>/preprocessor.js',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,8 @@
 module.exports = {
   modulePaths: ['<rootDir>/src/'],
-  moduleNameMapper:{
-	  '~/(.*)':'<rootDir>/src/$1'
-  },  
+  moduleNameMapper: {
+    '~/(.*)': '<rootDir>/src/$1'
+  },
   moduleFileExtensions: ['ts', 'tsx', 'js'],
   transform: {
     '^.+\\.(ts|tsx)$': '<rootDir>/preprocessor.js',

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "jest --coverage",
     "test:watch": "jest --watch",
     "build:rollup": "rollup src/index.ts -c",
-    "build:types": "tsc --declaration --emitDeclarationOnly",
+    "build:types": "ttsc --project ttsconfig.json",
     "build": "rimraf types lib && yarn run build:rollup && yarn run build:types",
     "prepublishOnly": "rimraf types lib && yarn build",
     "docs": "gitbook serve",
@@ -23,6 +23,7 @@
     "@types/jest": "^22.2.3",
     "@types/node": "^9.6.5",
     "@types/object-path": "^0.9.29",
+    "@zerollup/ts-transform-paths": "^1.1.2",
     "gh-pages": "^1.1.0",
     "gitbook": "^3.2.3",
     "gitbook-cli": "^2.3.2",
@@ -31,6 +32,7 @@
     "rollup": "^0.58.0",
     "rollup-plugin-typescript": "^0.8.1",
     "rollup-plugin-typescript2": "^0.11.1",
+    "ttypescript": "^1.2.0",
     "typescript": "^2.8.1"
   },
   "dependencies": {

--- a/src/domains/arg/compiler.ts
+++ b/src/domains/arg/compiler.ts
@@ -5,12 +5,11 @@ import {
   isInputType,
   GraphQLNonNull,
 } from 'graphql';
-import { resolveType } from 'services/utils';
-import { injectorRegistry } from 'domains/inject';
+import { resolveType, getParameterNames } from '~/services/utils';
+import { injectorRegistry } from '~/domains/inject';
 import { ArgsIndex, argRegistry } from './registry';
 import { ArgError } from './error';
 import { defaultArgOptions } from './options';
-import { getParameterNames } from 'services/utils';
 
 function compileInferedAndRegisterdArgs(infered: any[], registeredArgs: ArgsIndex = {}) {
   const argsMerged = infered.map((inferedType, index) => {

--- a/src/domains/arg/error.ts
+++ b/src/domains/arg/error.ts
@@ -1,6 +1,6 @@
-import { BaseError } from 'services/error';
+import { BaseError } from '~/services/error';
 
-import { getParameterNames } from 'services/utils';
+import { getParameterNames } from '~/services/utils';
 
 export class ArgError extends BaseError {
   constructor(target: Function, fieldName: string, argIndex: number, msg: string) {

--- a/src/domains/arg/registry.ts
+++ b/src/domains/arg/registry.ts
@@ -1,4 +1,4 @@
-import { DeepWeakMap } from 'services/utils';
+import { DeepWeakMap } from '~/services/utils';
 
 export interface ArgInnerConfig {
   description?: string;

--- a/src/domains/enum/error.ts
+++ b/src/domains/enum/error.ts
@@ -1,4 +1,4 @@
-import { BaseError } from 'services/error';
+import { BaseError } from '~/services/error';
 
 export class EnumError extends BaseError {
   constructor(name: string, msg: string) {

--- a/src/domains/field/compiler/fieldType.ts
+++ b/src/domains/field/compiler/fieldType.ts
@@ -1,8 +1,6 @@
 import { GraphQLType } from 'graphql';
-import { inferTypeByTarget } from 'services/utils';
+import { inferTypeByTarget, resolveType } from '~/services/utils';
 import { FieldError } from '../index';
-
-import { resolveType } from 'services/utils';
 
 export function resolveTypeOrThrow(
   type: any,

--- a/src/domains/field/compiler/index.ts
+++ b/src/domains/field/compiler/index.ts
@@ -1,9 +1,9 @@
 import { GraphQLFieldConfig, GraphQLFieldConfigMap } from 'graphql';
-import { getClassWithAllParentClasses } from 'services/utils/inheritance';
+import { getClassWithAllParentClasses } from '~/services/utils/inheritance';
 import { FieldError, fieldsRegistry } from '../index';
 
 import { compileFieldResolver } from './resolver';
-import { compileFieldArgs } from 'domains/arg';
+import { compileFieldArgs } from '~/domains/arg';
 import {
   enhanceType,
   isRootFieldOnNonRootBase,

--- a/src/domains/field/compiler/resolver.ts
+++ b/src/domains/field/compiler/resolver.ts
@@ -1,11 +1,11 @@
 import { GraphQLFieldResolver } from 'graphql';
-import { InjectorsIndex, InjectorResolver, injectorRegistry } from 'domains/inject';
+import { InjectorsIndex, InjectorResolver, injectorRegistry } from '~/domains/inject';
 import {
   fieldAfterHooksRegistry,
   fieldBeforeHooksRegistry,
   HookExecutor,
-} from 'domains/hooks';
-import { getParameterNames } from 'services/utils';
+} from '~/domains/hooks';
+import { getParameterNames } from '~/services/utils';
 
 interface ArgsMap {
   [argName: string]: any;

--- a/src/domains/field/compiler/services.ts
+++ b/src/domains/field/compiler/services.ts
@@ -6,7 +6,7 @@ import {
   schemaRootsRegistry,
   mutationFieldsRegistry,
   queryFieldsRegistry,
-} from 'domains/schema';
+} from '~/domains/schema';
 
 export function resolveRegisteredOrInferedType(
   target: Function,

--- a/src/domains/field/error.ts
+++ b/src/domains/field/error.ts
@@ -1,4 +1,4 @@
-import { BaseError } from 'services/error';
+import { BaseError } from '~/services/error';
 
 export class FieldError extends BaseError {
   constructor(target: Function, fieldName: string, msg: string) {

--- a/src/domains/field/registry.ts
+++ b/src/domains/field/registry.ts
@@ -1,4 +1,4 @@
-import { DeepWeakMap } from 'services/utils';
+import { DeepWeakMap } from '~/services/utils';
 
 export interface AllRegisteredFields {
   [fieldName: string]: FieldInnerConfig;

--- a/src/domains/hooks/error.ts
+++ b/src/domains/hooks/error.ts
@@ -1,4 +1,4 @@
-import { BaseError } from 'services/error';
+import { BaseError } from '~/services/error';
 
 export class HookError extends BaseError {
   constructor(target: Function, fieldName: string, msg: string) {

--- a/src/domains/hooks/registry.ts
+++ b/src/domains/hooks/registry.ts
@@ -1,5 +1,5 @@
 import { GraphQLResolveInfo } from 'graphql';
-import { DeepWeakMap } from 'services/utils';
+import { DeepWeakMap } from '~/services/utils';
 import { HookError } from './error';
 
 export interface HookExecutorResolverArgs {

--- a/src/domains/inject/registry.ts
+++ b/src/domains/inject/registry.ts
@@ -1,6 +1,6 @@
 import { GraphQLResolveInfo } from 'graphql';
 
-import { DeepWeakMap } from 'services/utils';
+import { DeepWeakMap } from '~/services/utils';
 
 export interface InjectorResolverData {
   source: any;

--- a/src/domains/inputField/compiler/fieldType.ts
+++ b/src/domains/inputField/compiler/fieldType.ts
@@ -1,8 +1,8 @@
 import { GraphQLType } from 'graphql';
-import { inferTypeByTarget } from 'services/utils';
+import { inferTypeByTarget } from '~/services/utils';
 import { InputFieldError } from '../index';
 
-import { resolveType } from 'services/utils';
+import { resolveType } from '~/services/utils';
 
 export function resolveTypeOrThrow(
   type: any,

--- a/src/domains/inputField/compiler/index.ts
+++ b/src/domains/inputField/compiler/index.ts
@@ -6,7 +6,7 @@ import {
   GraphQLInputFieldConfigMap,
   GraphQLNonNull,
 } from 'graphql';
-import { getClassWithAllParentClasses } from 'services/utils';
+import { getClassWithAllParentClasses } from '~/services/utils';
 import { InputFieldError, inputFieldsRegistry } from '../index';
 
 import { resolveTypeOrThrow, inferTypeOrThrow } from './fieldType';

--- a/src/domains/inputField/error.ts
+++ b/src/domains/inputField/error.ts
@@ -1,4 +1,4 @@
-import { BaseError } from 'services/error';
+import { BaseError } from '~/services/error';
 
 export class InputFieldError extends BaseError {
   constructor(target: Function, fieldName: string, msg: string) {

--- a/src/domains/inputField/registry.ts
+++ b/src/domains/inputField/registry.ts
@@ -1,4 +1,4 @@
-import { DeepWeakMap } from 'services/utils';
+import { DeepWeakMap } from '~/services/utils';
 
 export interface AllRegisteredInputFields {
   [fieldName: string]: FieldInputInnerConfig;

--- a/src/domains/inputObjectType/compiler/objectType.ts
+++ b/src/domains/inputObjectType/compiler/objectType.ts
@@ -1,8 +1,8 @@
 import { GraphQLInputObjectType, GraphQLInputFieldConfigMap } from 'graphql';
 import { InputObjectTypeError, inputObjectTypeRegistry } from '../index';
 
-import { compileAllInputFields, inputFieldsRegistry } from 'domains/inputField';
-import { createCachedThunk, getClassWithAllParentClasses } from 'services/utils';
+import { compileAllInputFields, inputFieldsRegistry } from '~/domains/inputField';
+import { createCachedThunk, getClassWithAllParentClasses } from '~/services/utils';
 
 const compileOutputTypeCache = new WeakMap<Function, GraphQLInputObjectType>();
 

--- a/src/domains/inputObjectType/error.ts
+++ b/src/domains/inputObjectType/error.ts
@@ -1,4 +1,4 @@
-import { BaseError } from 'services/error';
+import { BaseError } from '~/services/error';
 
 export class InputObjectTypeError extends BaseError {
   constructor(target: Function, msg: string) {

--- a/src/domains/objectType/compiler/objectType.ts
+++ b/src/domains/objectType/compiler/objectType.ts
@@ -1,8 +1,8 @@
 import { GraphQLObjectType } from 'graphql';
 import { ObjectTypeError, objectTypeRegistry } from '../index';
 
-import { compileAllFields, fieldsRegistry } from 'domains/field';
-import { createCachedThunk, getClassWithAllParentClasses } from 'services/utils';
+import { compileAllFields, fieldsRegistry } from '~/domains/field';
+import { createCachedThunk, getClassWithAllParentClasses } from '~/services/utils';
 
 const compileOutputTypeCache = new WeakMap<Function, GraphQLObjectType>();
 

--- a/src/domains/objectType/error.ts
+++ b/src/domains/objectType/error.ts
@@ -1,4 +1,4 @@
-import { BaseError } from 'services/error';
+import { BaseError } from '~/services/error';
 
 export class ObjectTypeError extends BaseError {
   constructor(target: Function, msg: string) {

--- a/src/domains/schema/compiler.ts
+++ b/src/domains/schema/compiler.ts
@@ -6,7 +6,7 @@ import {
   RootFieldsRegistry,
 } from './registry';
 import { SchemaRootError } from './error';
-import { showDeprecationWarning } from 'services/utils';
+import { showDeprecationWarning } from '~/services/utils';
 
 function validateSchemaRoots(roots: Function[]) {
   for (let root of roots) {
@@ -16,7 +16,7 @@ function validateSchemaRoots(roots: Function[]) {
   }
 }
 
-interface CompileSchemaOptions {
+export interface CompileSchemaOptions {
   roots: Function[];
 }
 

--- a/src/domains/schema/error.ts
+++ b/src/domains/schema/error.ts
@@ -1,4 +1,4 @@
-import { BaseError } from 'services/error';
+import { BaseError } from '~/services/error';
 
 export class SchemaRootError extends BaseError {
   constructor(target: Function, msg: string) {

--- a/src/domains/schema/index.ts
+++ b/src/domains/schema/index.ts
@@ -4,7 +4,7 @@ export {
   queryFieldsRegistry,
 } from './registry';
 import { schemaRootsRegistry, SchemaRootConfig } from './registry';
-import { showDeprecationWarning } from 'services/utils';
+import { showDeprecationWarning } from '~/services/utils';
 // import { compileSchema } from './compiler';
 export { compileSchema } from './compiler';
 export { Query, Mutation } from './rootFields';

--- a/src/domains/schema/registry.ts
+++ b/src/domains/schema/registry.ts
@@ -1,7 +1,7 @@
 import { GraphQLFieldConfig } from 'graphql';
-import { DeepWeakMap } from 'services/utils';
+import { DeepWeakMap } from '~/services/utils';
 
-type Getter<Result> = () => Result;
+export type Getter<Result> = () => Result;
 
 export interface SchemaRootConfig {}
 

--- a/src/domains/schema/rootFields.ts
+++ b/src/domains/schema/rootFields.ts
@@ -1,4 +1,4 @@
-import { Field, FieldOptions, compileFieldConfig } from 'domains/field';
+import { Field, FieldOptions, compileFieldConfig } from '~/domains/field';
 import {
   queryFieldsRegistry,
   mutationFieldsRegistry,

--- a/src/domains/union/compiler.ts
+++ b/src/domains/union/compiler.ts
@@ -5,8 +5,8 @@ import {
   GraphQLType,
 } from 'graphql';
 
-import { resolveTypesList, isObjectType, resolveType } from 'services/utils';
-import { Thunk } from 'services/types';
+import { resolveTypesList, isObjectType, resolveType } from '~/services/utils';
+import { Thunk } from '~/services/types';
 import { UnionError } from './error';
 
 export interface UnionTypeResolver {

--- a/src/domains/union/error.ts
+++ b/src/domains/union/error.ts
@@ -1,4 +1,4 @@
-import { BaseError } from 'services/error';
+import { BaseError } from '~/services/error';
 
 export class UnionError extends BaseError {
   constructor(target: Function, msg: string) {

--- a/src/domains/union/index.ts
+++ b/src/domains/union/index.ts
@@ -1,4 +1,4 @@
-import { Thunk } from 'services/types';
+import { Thunk } from '~/services/types';
 import { unionRegistry } from './registry';
 export { unionRegistry } from './registry';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,4 +18,7 @@ export {
   compileObjectType,
   compileInputObjectType,
   registerEnum,
+  Schema,
+  After,
+  Before  
 } from './domains';

--- a/src/services/utils/gql/types/resolve.ts
+++ b/src/services/utils/gql/types/resolve.ts
@@ -1,75 +1,76 @@
 import { isType, GraphQLType, GraphQLList, GraphQLNonNull } from 'graphql';
-import { Thunk } from 'services/types';
+import { Thunk } from '~/services/types';
 import {
-  objectTypeRegistry,
-  compileObjectType,
-  inputObjectTypeRegistry,
-  compileInputObjectType,
-} from 'domains';
-import { enumsRegistry, unionRegistry } from 'domains';
+	objectTypeRegistry,
+	compileObjectType,
+	inputObjectTypeRegistry,
+	compileInputObjectType,
+	enumsRegistry, 
+	unionRegistry
+} from '~/domains';
 import { parseNativeTypeToGraphQL, isParsableScalar } from './parseNative';
 
 export function resolveType(input: any, allowThunk = true): GraphQLType {
-  if (isType(input)) {
-    return input;
-  }
+	if (isType(input)) {
+		return input;
+	}
 
-  if (isParsableScalar(input)) {
-    return parseNativeTypeToGraphQL(input);
-  }
+	if (isParsableScalar(input)) {
+		return parseNativeTypeToGraphQL(input);
+	}
 
-  if (Array.isArray(input)) {
-    return resolveListType(input);
-  }
+	if (Array.isArray(input)) {
+		return resolveListType(input);
+	}
 
-  if (enumsRegistry.has(input)) {
-    return enumsRegistry.get(input);
-  }
+	if (enumsRegistry.has(input)) {
+		return enumsRegistry.get(input);
+	}
 
-  if (unionRegistry.has(input)) {
-    return unionRegistry.get(input)();
-  }
+	if (unionRegistry.has(input)) {
+		return unionRegistry.get(input)();
+	}
 
-  if (objectTypeRegistry.has(input)) {
-    return compileObjectType(input);
-  }
+	if (objectTypeRegistry.has(input)) {
+		return compileObjectType(input);
+	}
 
-  if (inputObjectTypeRegistry.has(input)) {
-    return compileInputObjectType(input);
-  }
+	if (inputObjectTypeRegistry.has(input)) {
+		return compileInputObjectType(input);
+	}
 
-  if (input === Promise) {
-    return;
-  }
+	if (input === Promise) {
+		return;
+	}
 
-  if (!allowThunk || typeof input !== 'function') {
-    return;
-  }
+	if (!allowThunk || typeof input !== 'function') {
+		return;
+	}
 
-  return resolveType(input(), false);
+	return resolveType(input(), false);
 }
 
 function resolveListType(input: any[]): GraphQLType {
-  if (input.length !== 1) {
-    return;
-  }
-  const [itemType] = input;
+	if (input.length !== 1) {
+		return;
+	}
+	const [itemType] = input;
 
-  const resolvedItemType = resolveType(itemType);
+	const resolvedItemType = resolveType(itemType);
 
-  if (!resolvedItemType) {
-    return;
-  }
-  return new GraphQLList(new GraphQLNonNull(resolvedItemType));
+	if (!resolvedItemType) {
+		return;
+	}
+	return new GraphQLList(new GraphQLNonNull(resolvedItemType));
 }
 
 export function resolveTypesList(types: Thunk<any[]>): GraphQLType[] {
-  if (Array.isArray(types)) {
-    return types.map(type => {
-      return resolveType(type);
-    });
-  }
-  return types().map(type => {
-    return resolveType(type);
-  });
+	if (Array.isArray(types)) {
+		return types.map(type => {
+			return resolveType(type);
+		});
+	}
+	return types().map(type => {
+		return resolveType(type);
+	});
 }

--- a/src/services/utils/gql/types/resolve.ts
+++ b/src/services/utils/gql/types/resolve.ts
@@ -1,76 +1,76 @@
 import { isType, GraphQLType, GraphQLList, GraphQLNonNull } from 'graphql';
 import { Thunk } from '~/services/types';
 import {
-	objectTypeRegistry,
-	compileObjectType,
-	inputObjectTypeRegistry,
-	compileInputObjectType,
-	enumsRegistry, 
-	unionRegistry
+  objectTypeRegistry,
+  compileObjectType,
+  inputObjectTypeRegistry,
+  compileInputObjectType,
+  enumsRegistry,
+  unionRegistry
 } from '~/domains';
 import { parseNativeTypeToGraphQL, isParsableScalar } from './parseNative';
 
 export function resolveType(input: any, allowThunk = true): GraphQLType {
-	if (isType(input)) {
-		return input;
-	}
+  if (isType(input)) {
+    return input;
+  }
 
-	if (isParsableScalar(input)) {
-		return parseNativeTypeToGraphQL(input);
-	}
+  if (isParsableScalar(input)) {
+    return parseNativeTypeToGraphQL(input);
+  }
 
-	if (Array.isArray(input)) {
-		return resolveListType(input);
-	}
+  if (Array.isArray(input)) {
+    return resolveListType(input);
+  }
 
-	if (enumsRegistry.has(input)) {
-		return enumsRegistry.get(input);
-	}
+  if (enumsRegistry.has(input)) {
+    return enumsRegistry.get(input);
+  }
 
-	if (unionRegistry.has(input)) {
-		return unionRegistry.get(input)();
-	}
+  if (unionRegistry.has(input)) {
+    return unionRegistry.get(input)();
+  }
 
-	if (objectTypeRegistry.has(input)) {
-		return compileObjectType(input);
-	}
+  if (objectTypeRegistry.has(input)) {
+    return compileObjectType(input);
+  }
 
-	if (inputObjectTypeRegistry.has(input)) {
-		return compileInputObjectType(input);
-	}
+  if (inputObjectTypeRegistry.has(input)) {
+    return compileInputObjectType(input);
+  }
 
-	if (input === Promise) {
-		return;
-	}
+  if (input === Promise) {
+    return;
+  }
 
-	if (!allowThunk || typeof input !== 'function') {
-		return;
-	}
+  if (!allowThunk || typeof input !== 'function') {
+    return;
+  }
 
-	return resolveType(input(), false);
+  return resolveType(input(), false);
 }
 
 function resolveListType(input: any[]): GraphQLType {
-	if (input.length !== 1) {
-		return;
-	}
-	const [itemType] = input;
+  if (input.length !== 1) {
+    return;
+  }
+  const [itemType] = input;
 
-	const resolvedItemType = resolveType(itemType);
+  const resolvedItemType = resolveType(itemType);
 
-	if (!resolvedItemType) {
-		return;
-	}
-	return new GraphQLList(new GraphQLNonNull(resolvedItemType));
+  if (!resolvedItemType) {
+    return;
+  }
+  return new GraphQLList(new GraphQLNonNull(resolvedItemType));
 }
 
 export function resolveTypesList(types: Thunk<any[]>): GraphQLType[] {
-	if (Array.isArray(types)) {
-		return types.map(type => {
-			return resolveType(type);
-		});
-	}
-	return types().map(type => {
-		return resolveType(type);
-	});
+  if (Array.isArray(types)) {
+    return types.map(type => {
+      return resolveType(type);
+    });
+  }
+  return types().map(type => {
+    return resolveType(type);
+  });
 }

--- a/src/test/arg/basics.spec.ts
+++ b/src/test/arg/basics.spec.ts
@@ -1,5 +1,5 @@
 import { GraphQLString, GraphQLNonNull } from 'graphql';
-import { Field, ObjectType, compileObjectType, Arg } from 'domains';
+import { Field, ObjectType, compileObjectType, Arg } from '~/domains';
 
 describe('Arguments with @Arg', () => {
   it('Allows setting argument with @Arg decorator', () => {

--- a/src/test/arg/complex.spec.ts
+++ b/src/test/arg/complex.spec.ts
@@ -7,7 +7,7 @@ import {
   InputField,
   InputObjectType,
   Arg,
-} from 'domains';
+} from '~/domains';
 
 describe('Complex arguments', () => {
   it('should not allow complex argument type not decorated with @InputObjectType', async () => {

--- a/src/test/arg/infering.spec.ts
+++ b/src/test/arg/infering.spec.ts
@@ -1,5 +1,5 @@
 import { GraphQLString, GraphQLFloat, GraphQLNonNull } from 'graphql';
-import { Field, ObjectType, compileObjectType } from 'domains';
+import { Field, ObjectType, compileObjectType } from '~/domains';
 
 describe('Arguments', () => {
   it('Infers basic arguments without @Arg decorator', () => {

--- a/src/test/enum/index.spec.ts
+++ b/src/test/enum/index.spec.ts
@@ -1,5 +1,5 @@
-import { registerEnum } from 'domains';
-import { resolveType } from 'services/utils';
+import { registerEnum } from '~/domains';
+import { resolveType } from '~/services/utils';
 
 describe('Enums', () => {
   it('Registers returns proper enum type', () => {

--- a/src/test/field/index.spec.ts
+++ b/src/test/field/index.spec.ts
@@ -5,7 +5,7 @@ import {
   isNamedType,
   getNamedType,
 } from 'graphql';
-import { ObjectType, Field, compileObjectType } from 'domains';
+import { ObjectType, Field, compileObjectType } from '~/domains';
 
 import 'reflect-metadata';
 

--- a/src/test/field/special-fields.spec.ts
+++ b/src/test/field/special-fields.spec.ts
@@ -1,4 +1,4 @@
-import { ObjectType, Query, compileObjectType } from 'domains';
+import { ObjectType, Query, compileObjectType } from '~/domains';
 
 describe('Special fields - @Query, @Mutation @Subscribe', () => {
   it('Will not allow registering special type on type that is not @Schema', () => {

--- a/src/test/functional/enum.spec.ts
+++ b/src/test/functional/enum.spec.ts
@@ -6,7 +6,7 @@ import {
   Arg,
   Field,
   registerEnum,
-} from 'domains';
+} from '~/domains';
 import { graphql } from 'graphql';
 
 enum TestEnum {

--- a/src/test/functional/mutation.spec.ts
+++ b/src/test/functional/mutation.spec.ts
@@ -7,7 +7,7 @@ import {
   Mutation,
   InputField,
   InputObjectType,
-} from 'domains';
+} from '~/domains';
 import { graphql } from 'graphql';
 
 @InputObjectType()

--- a/src/test/functional/query.spec.ts
+++ b/src/test/functional/query.spec.ts
@@ -1,4 +1,4 @@
-import { Query, SchemaRoot, compileSchema, ObjectType, Field } from 'domains';
+import { Query, SchemaRoot, compileSchema, ObjectType, Field } from '~/domains';
 import { graphql } from 'graphql';
 
 @ObjectType()

--- a/src/test/hooks/index.spec.ts
+++ b/src/test/hooks/index.spec.ts
@@ -1,4 +1,4 @@
-import { ObjectType, Field, Before, After, compileObjectType } from 'domains';
+import { ObjectType, Field, Before, After, compileObjectType } from '~/domains';
 
 describe('Hooks', () => {
   it('Will call @Before hook on field resolve', async () => {

--- a/src/test/inject/index.spec.ts
+++ b/src/test/inject/index.spec.ts
@@ -7,7 +7,7 @@ import {
   Context,
   Source,
   Info,
-} from 'domains';
+} from '~/domains';
 
 import { wait } from '../utils';
 

--- a/src/test/inputObjectType/index.spec.ts
+++ b/src/test/inputObjectType/index.spec.ts
@@ -1,6 +1,6 @@
 import { GraphQLObjectType } from 'graphql';
-import { ObjectType, compileObjectType } from 'domains';
-import { Field } from 'domains/field';
+import { ObjectType, compileObjectType } from '~/domains';
+import { Field } from '~/domains/field';
 
 describe('Type', () => {
   it('Throws when trying to compile type without @ObjectType decorator', () => {

--- a/src/test/inputObjectType/inheritance.spec.ts
+++ b/src/test/inputObjectType/inheritance.spec.ts
@@ -1,5 +1,5 @@
 import { GraphQLString, GraphQLNonNull } from 'graphql';
-import { InputObjectType, InputField, compileInputObjectType } from 'domains';
+import { InputObjectType, InputField, compileInputObjectType } from '~/domains';
 
 describe('Type inheritance', () => {
   it('Will pass input fields from parent class', () => {

--- a/src/test/misc/index.spec.ts
+++ b/src/test/misc/index.spec.ts
@@ -1,4 +1,4 @@
-import { showDeprecationWarning } from 'services/utils';
+import { showDeprecationWarning } from '~/services/utils';
 
 describe('showDeprecationWarning', () => {
   it('Will not show deprecation warning twice for the same object', async () => {

--- a/src/test/objectType/index.spec.ts
+++ b/src/test/objectType/index.spec.ts
@@ -1,6 +1,6 @@
 import { GraphQLObjectType } from 'graphql';
-import { ObjectType, compileObjectType } from 'domains';
-import { Field } from 'domains/field';
+import { ObjectType, compileObjectType } from '~/domains';
+import { Field } from '~/domains/field';
 
 describe('Type', () => {
   it('Throws when trying to compile type without @ObjectType decorator', () => {

--- a/src/test/objectType/inheritance.spec.ts
+++ b/src/test/objectType/inheritance.spec.ts
@@ -1,5 +1,5 @@
 import { GraphQLString, GraphQLNonNull } from 'graphql';
-import { ObjectType, compileObjectType, Field } from 'domains';
+import { ObjectType, compileObjectType, Field } from '~/domains';
 
 describe('Type inheritance', () => {
   it('Will pass fields from parent class', () => {

--- a/src/test/schema/index.spec.ts
+++ b/src/test/schema/index.spec.ts
@@ -1,4 +1,4 @@
-import { Query, SchemaRoot, compileSchema, ObjectType, Field, Mutation } from 'domains';
+import { Query, SchemaRoot, compileSchema, ObjectType, Field, Mutation } from '~/domains';
 import {
   graphql,
   introspectionQuery,

--- a/src/test/union/index.spec.ts
+++ b/src/test/union/index.spec.ts
@@ -1,6 +1,6 @@
 import { GraphQLUnionType } from 'graphql';
-import { ObjectType, Union, Field, compileObjectType } from 'domains';
-import { resolveType } from 'services/utils';
+import { ObjectType, Union, Field, compileObjectType } from '~/domains';
+import { resolveType } from '~/services/utils';
 
 @ObjectType()
 class Sub1 {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,17 @@
 {
-  "compilerOptions": {
+  "compilerOptions": {	
     "module": "commonjs",
     "lib": ["es2017"],
     "target": "es5",
     "noImplicitAny": true,
     "noImplicitUseStrict": true,
     "pretty": true,
-    "baseUrl": "./src",
+    "baseUrl": ".",
     "rootDir": "./src",
-    "outDir": "./lib",
+	"outDir": "./lib",
+	"paths": {
+		"~/*":["src/*"]
+	},
     "declarationDir": "./types",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,21 @@
 {
-  "compilerOptions": {	
+  "compilerOptions": {
     "module": "commonjs",
-    "lib": ["es2017"],
+    "lib": [
+      "es2017"
+    ],
     "target": "es5",
     "noImplicitAny": true,
     "noImplicitUseStrict": true,
     "pretty": true,
     "baseUrl": ".",
     "rootDir": "./src",
-	"outDir": "./lib",
-	"paths": {
-		"~/*":["src/*"]
-	},
+    "outDir": "./lib",
+    "paths": {
+      "~/*": [
+        "src/*"
+      ]
+    },
     "declarationDir": "./types",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
@@ -20,5 +24,7 @@
     "stripInternal": true,
     "sourceMap": true
   },
-  "exclude": ["./examples"]
+  "exclude": [
+    "./examples"
+  ]
 }

--- a/ttsconfig.json
+++ b/ttsconfig.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://schemastore.azurewebsites.net/schemas/json/tsconfig.json",
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"declaration": true,
+		"emitDeclarationOnly": true,
+		"plugins": [
+            { "transform": "@zerollup/ts-transform-paths" }
+        ]
+	}
+}

--- a/ttsconfig.json
+++ b/ttsconfig.json
@@ -1,11 +1,13 @@
 {
-	"$schema": "https://schemastore.azurewebsites.net/schemas/json/tsconfig.json",
-	"extends": "./tsconfig.json",
-	"compilerOptions": {
-		"declaration": true,
-		"emitDeclarationOnly": true,
-		"plugins": [
-            { "transform": "@zerollup/ts-transform-paths" }
-        ]
-	}
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/tsconfig.json",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "plugins": [
+      {
+        "transform": "@zerollup/ts-transform-paths"
+      }
+    ]
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,6 +36,19 @@
   version "0.9.29"
   resolved "https://registry.yarnpkg.com/@types/object-path/-/object-path-0.9.29.tgz#fca97eef86e8d78f3d5ada611b30289ec7cc90e8"
 
+"@zerollup/ts-helpers@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@zerollup/ts-helpers/-/ts-helpers-1.1.1.tgz#57d078bb064ce601fb1754ea919b45427ed8fd23"
+  dependencies:
+    resolve "^1.7.1"
+
+"@zerollup/ts-transform-paths@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@zerollup/ts-transform-paths/-/ts-transform-paths-1.1.2.tgz#d62166a7346279533da069692e0a27ec8c1b0031"
+  dependencies:
+    "@zerollup/ts-helpers" "^1.1.1"
+    compare-versions "^3.1.0"
+
 JSONStream@~1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.2.tgz#c102371b6ec3a7cf3b847ca00c20bb0fce4c6dea"
@@ -259,7 +272,7 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
 
-arrify@^1.0.1:
+arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
@@ -802,6 +815,14 @@ chalk@^2.0.0, chalk@^2.0.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 char-spinner@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/char-spinner/-/char-spinner-1.0.1.tgz#e6ea67bd247e107112983b7ab0479ed362800081"
@@ -1291,7 +1312,7 @@ dezalgo@^1.0.0, dezalgo@^1.0.1, dezalgo@^1.0.2, dezalgo@~1.0.3:
     asap "^2.0.0"
     wrappy "1"
 
-diff@^3.2.0:
+diff@^3.1.0, diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
@@ -3580,6 +3601,10 @@ make-dir@^1.0.0:
   dependencies:
     pify "^3.0.0"
 
+make-error@^1.1.1:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.4.tgz#19978ed575f9e9545d2ff8c13e33b5d18a67d535"
+
 make-fetch-happen@^2.4.13:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-2.6.0.tgz#8474aa52198f6b1ae4f3094c04e8370d35ea8a38"
@@ -5360,7 +5385,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.0.0, resolve@^1.5.0:
+resolve@^1.0.0, resolve@^1.5.0, resolve@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
   dependencies:
@@ -5699,6 +5724,13 @@ source-map-support@^0.5.0:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.4.tgz#54456efa89caa9270af7cd624cc2f123e51fbae8"
   dependencies:
+    source-map "^0.6.0"
+
+source-map-support@^0.5.3:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.5.tgz#0d4af9e00493e855402e8ec36ebed2d266fceb90"
+  dependencies:
+    buffer-from "^1.0.0"
     source-map "^0.6.0"
 
 source-map-url@^0.4.0:
@@ -6097,9 +6129,29 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
+ts-node@^6.0.2:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-6.0.3.tgz#28bf74bcad134fad17f7469dad04638ece03f0f4"
+  dependencies:
+    arrify "^1.0.0"
+    chalk "^2.3.0"
+    diff "^3.1.0"
+    make-error "^1.1.1"
+    minimist "^1.2.0"
+    mkdirp "^0.5.1"
+    source-map-support "^0.5.3"
+    yn "^2.0.0"
+
 tslib@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
+
+ttypescript@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ttypescript/-/ttypescript-1.2.0.tgz#cacf507749b89cf783f992ae582233db6907a2ae"
+  dependencies:
+    resolve "^1.7.1"
+    ts-node "^6.0.2"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -6576,3 +6628,7 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yn@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"


### PR DESCRIPTION
Added '~' path to refer to `./src` in tsconfig
Changed jest module resolution to understand that `~` referes to `./src`
Added `ttypescript` and `@zerollup/ts-transform-paths` to transform paths
Changed `build:types` task to use `ttsc` with transform.
fixes prismake/typegql/issues/#23