### PR TITLE
Falsy values of field dont cause it to be ignored. Only undefined does.

### DIFF
--- a/src/domains/field/compiler/resolver.ts
+++ b/src/domains/field/compiler/resolver.ts
@@ -59,6 +59,20 @@ function computeFinalArgs(
   });
 }
 
+function getFieldOfTarget(instance: any, prototype: any, fieldName: string) {
+  if (!instance) {
+    return prototype[fieldName];
+  }
+
+  const instanceField = instance[fieldName];
+
+  if (instanceField !== undefined) {
+    return instanceField
+  }
+
+  return prototype[fieldName];
+}
+
 export function compileFieldResolver(
   target: Function,
   fieldName: string,
@@ -70,8 +84,7 @@ export function compileFieldResolver(
 
   return async (source: any, args = null, context = null, info = null) => {
     await performHooksExecution(beforeHooks, source, args, context, info);
-    const instanceField =
-      (source && source[fieldName]) || target.prototype[fieldName];
+    const instanceField = getFieldOfTarget(source, target.prototype, fieldName);
 
     if (typeof instanceField !== 'function') {
       await performHooksExecution(afterHooks, source, args, context, info);

--- a/src/test/field/index.spec.ts
+++ b/src/test/field/index.spec.ts
@@ -231,4 +231,32 @@ describe('Field', () => {
       compileObjectType(Foo).getFields(),
     ).toThrowErrorMatchingSnapshot();
   });
+
+  it('Properly resolves edge cases default values of fields', async () => {
+    @ObjectType()
+    class Foo {
+      @Field() undef: boolean = undefined;
+      @Field() falsy: boolean = false;
+      @Field() truthy: boolean = true;
+      @Field() nully: boolean = null;
+      @Field() zero: number = 0;
+      @Field() maxInt: number = Number.MAX_SAFE_INTEGER;
+    }
+    const compiled = compileObjectType(Foo);
+
+    const {undef, falsy, truthy, nully, zero, maxInt} = compiled.getFields();
+    
+
+    const foo = new Foo();
+
+    expect(await undef.resolve(foo, {}, null, null)).toEqual(undefined);
+    expect(await falsy.resolve(foo, {}, null, null)).toEqual(false);
+    expect(await truthy.resolve(foo, {}, null, null)).toEqual(true);
+    expect(await nully.resolve(foo, {}, null, null)).toEqual(null);
+    expect(await zero.resolve(foo, {}, null, null)).toEqual(0);
+    expect(await maxInt.resolve(foo, {}, null, null)).toEqual(
+      9007199254740991
+    );
+  });
+
 });


### PR DESCRIPTION
Fixes #28 

Thanks for pointing it! It was silly mistake!