### PR TITLE
Feature/root class instances

### DIFF
--- a/src/domains/field/compiler/resolver.ts
+++ b/src/domains/field/compiler/resolver.ts
@@ -83,6 +83,7 @@ export function compileFieldResolver(
   const afterHooks = fieldAfterHooksRegistry.get(target, fieldName);
 
   return async (source: any, args = null, context = null, info = null) => {
+    console.log(source, target);
     await performHooksExecution(beforeHooks, source, args, context, info);
     const instanceField = getFieldOfTarget(source, target.prototype, fieldName);
 

--- a/src/domains/field/compiler/resolver.ts
+++ b/src/domains/field/compiler/resolver.ts
@@ -11,6 +11,8 @@ import {
 } from '~/domains/hooks';
 import { getParameterNames } from '~/services/utils';
 
+import { isSchemaRoot, getSchemaRootInstance } from "~/domains/schema";
+
 interface ArgsMap {
   [argName: string]: any;
 }
@@ -83,7 +85,10 @@ export function compileFieldResolver(
   const afterHooks = fieldAfterHooksRegistry.get(target, fieldName);
 
   return async (source: any, args = null, context = null, info = null) => {
-    console.log(source, target);
+    if (isSchemaRoot(target)) {
+      source = getSchemaRootInstance(target);
+    }
+
     await performHooksExecution(beforeHooks, source, args, context, info);
     const instanceField = getFieldOfTarget(source, target.prototype, fieldName);
 

--- a/src/domains/field/compiler/services.ts
+++ b/src/domains/field/compiler/services.ts
@@ -11,6 +11,8 @@ import {
   schemaRootsRegistry,
   mutationFieldsRegistry,
   queryFieldsRegistry,
+  isSchemaRoot,
+  getSchemaRootInstance
 } from '~/domains/schema';
 
 export function resolveRegisteredOrInferedType(
@@ -50,8 +52,9 @@ export function enhanceType(
   return finalType;
 }
 
+
 export function isRootFieldOnNonRootBase(base: Function, fieldName: string) {
-  const isRoot = schemaRootsRegistry.has(base);
+  const isRoot = isSchemaRoot(base);
   if (isRoot) {
     return false;
   }

--- a/src/domains/schema/compiler.ts
+++ b/src/domains/schema/compiler.ts
@@ -2,22 +2,12 @@ import { GraphQLSchema, GraphQLObjectType, GraphQLFieldConfig } from 'graphql';
 import {
   queryFieldsRegistry,
   mutationFieldsRegistry,
-  schemaRootsRegistry,
   RootFieldsRegistry,
 } from './registry';
 import { SchemaRootError } from './error';
 import { showDeprecationWarning } from '~/services/utils';
 
-function validateSchemaRoots(roots: Function[]) {
-  for (let root of roots) {
-    if (!schemaRootsRegistry.has(root)) {
-      throw new SchemaRootError(
-        root,
-        `Schema root must be registered with @SchemaRoot`,
-      );
-    }
-  }
-}
+import { validateSchemaRoots } from "./services";
 
 export interface CompileSchemaOptions {
   roots: Function[];

--- a/src/domains/schema/error.ts
+++ b/src/domains/schema/error.ts
@@ -15,3 +15,10 @@ export class SchemaFieldError extends BaseError {
     this.message = fullMsg;
   }
 }
+export class SchemaCompilationError extends BaseError {
+  constructor(msg: string) {
+    const fullMsg = `SchemaCompilationError: ${msg}`;
+    super(fullMsg);
+    this.message = fullMsg;
+  }
+}

--- a/src/domains/schema/index.ts
+++ b/src/domains/schema/index.ts
@@ -8,6 +8,7 @@ import { showDeprecationWarning } from '~/services/utils';
 // import { compileSchema } from './compiler';
 export { compileSchema } from './compiler';
 export { Query, Mutation } from './rootFields';
+export { isSchemaRoot, getSchemaRootInstance } from './services'
 
 export function SchemaRoot(config: SchemaRootConfig = {}): ClassDecorator {
   return target => {

--- a/src/domains/schema/rootFields.ts
+++ b/src/domains/schema/rootFields.ts
@@ -30,20 +30,25 @@ function requireSchemaRoot(target: Function, fieldName: string) {
   );
 }
 
+function getFieldCompiler(target: Function, fieldName: string) {
+  const fieldCompiler = () => {
+    requireSchemaRoot(target, fieldName);
+    const compiledField = compileFieldConfig(
+      target,
+      fieldName,
+    );
+    return compiledField;
+  };
+
+  return fieldCompiler;
+}
+
 // special fields
 export function Query(options?: FieldOptions): PropertyDecorator {
   return (targetInstance: Object, fieldName: string) => {
     validateRootSchemaField(targetInstance, fieldName);
     Field(options)(targetInstance, fieldName);
-    const fieldCompiler = () => {
-      requireSchemaRoot(targetInstance.constructor, fieldName);
-      const compiledField = compileFieldConfig(
-        targetInstance.constructor,
-        fieldName,
-      );
-      compiledField.type;
-      return compiledField;
-    };
+    const fieldCompiler = getFieldCompiler(targetInstance.constructor, fieldName);
     queryFieldsRegistry.set(
       targetInstance.constructor,
       fieldName,
@@ -54,15 +59,9 @@ export function Query(options?: FieldOptions): PropertyDecorator {
 
 export function Mutation(options?: FieldOptions): PropertyDecorator {
   return (targetInstance: Object, fieldName: string) => {
+    validateRootSchemaField(targetInstance, fieldName);
     Field(options)(targetInstance, fieldName);
-    const fieldCompiler = () => {
-      const compiledField = compileFieldConfig(
-        targetInstance.constructor,
-        fieldName,
-      );
-      compiledField.type;
-      return compiledField;
-    };
+    const fieldCompiler = getFieldCompiler(targetInstance.constructor, fieldName);
     mutationFieldsRegistry.set(
       targetInstance.constructor,
       fieldName,

--- a/src/domains/schema/services.ts
+++ b/src/domains/schema/services.ts
@@ -1,0 +1,42 @@
+import { Constructable } from "~/services/types";
+import {
+  schemaRootsRegistry,
+} from './registry';
+import { SchemaRootError, SchemaCompilationError } from './error';
+
+function hasDuplicates(arr: Function[]) {
+  return (new Set(arr)).size !== arr.length;
+}
+
+export function isSchemaRoot(base: Function) {
+  return schemaRootsRegistry.has(base);
+}
+
+export function validateSchemaRoots(roots: Function[]) {
+  if (hasDuplicates(roots)) {
+    throw new SchemaCompilationError(`At least one schema root is provided more than once in schema roots`);
+  }
+  for (let root of roots) {
+    if (!schemaRootsRegistry.has(root)) {
+      throw new SchemaRootError(
+        root,
+        `Schema root must be registered with @SchemaRoot`,
+      );
+    }
+  }
+}
+
+const schemaRootInstances = new WeakMap<Function, Object>();
+
+export function getSchemaRootInstance(schemaRootClass: Function) {
+  if (!isSchemaRoot(schemaRootClass)) {
+    return null;
+  }
+
+  if (schemaRootInstances.has(schemaRootClass)) {
+    return schemaRootInstances.get(schemaRootClass);
+  }
+  const instance = new (schemaRootClass as Constructable)();
+  schemaRootInstances.set(schemaRootClass, instance);
+  return instance;
+}

--- a/src/services/types/index.ts
+++ b/src/services/types/index.ts
@@ -1,3 +1,3 @@
 export type Thunk<Result> = Result | (() => Result);
 
-export type AnyClass = { new (): any };
+export type Constructable = { new (): any };

--- a/src/services/utils/deprecation/index.ts
+++ b/src/services/utils/deprecation/index.ts
@@ -1,9 +1,11 @@
 const shownRegistry = new WeakMap<any, true>();
 
+type Logger = (msg: string) => void;
+
 export function showDeprecationWarning(
   message: string,
   uniqueIdentifier?: any,
-  callback?: (message: string) => void,
+  logger: Logger = console.log
 ) {
   if (uniqueIdentifier && shownRegistry.has(uniqueIdentifier)) {
     return;
@@ -11,8 +13,5 @@ export function showDeprecationWarning(
   if (uniqueIdentifier) {
     shownRegistry.set(uniqueIdentifier, true);
   }
-  console.warn(`@Deprecation warning: ${message}`);
-  if (callback) {
-    callback(message);
-  }
+  logger(`@Deprecation warning: ${message}`);
 }

--- a/src/test/schema/index.spec.ts
+++ b/src/test/schema/index.spec.ts
@@ -206,25 +206,24 @@ describe('@SchemaRoot', () => {
 
     expect(result.data.foo).toEqual(42);
   });
+
   it('should call schema root constructor', async () => {
     const constructorCall = jest.fn();
     @SchemaRoot()
     class FooSchema {
-      private bar: number;
       constructor() {
         constructorCall();
-        this.bar = 42;
       }
 
       @Query()
       foo(): number {
-        return this.bar;
+        return 42;
       }
     }
 
     const schema = compileSchema({ roots: [FooSchema] });
 
-    const result = await graphql(
+    await graphql(
       schema,
       `
         {
@@ -234,6 +233,5 @@ describe('@SchemaRoot', () => {
     );
 
     expect(constructorCall).toBeCalled();
-    expect(result.data.foo).toEqual(42);
   });
 });

--- a/src/test/schema/index.spec.ts
+++ b/src/test/schema/index.spec.ts
@@ -181,4 +181,59 @@ describe('@SchemaRoot', () => {
       compileSchema({ roots: [FooSchema] }),
     ).toThrowErrorMatchingSnapshot();
   });
+
+  it('should support schema root instance properties', async () => {
+    @SchemaRoot()
+    class FooSchema {
+      private bar: number = 42;
+
+      @Query()
+      foo(): number {
+        return this.bar;
+      }
+    }
+
+    const schema = compileSchema({ roots: [FooSchema] });
+
+    const result = await graphql(
+      schema,
+      `
+        {
+          foo
+        }
+      `,
+    );
+
+    expect(result.data.foo).toEqual(42);
+  });
+  it('should call schema root constructor', async () => {
+    const constructorCall = jest.fn();
+    @SchemaRoot()
+    class FooSchema {
+      private bar: number;
+      constructor() {
+        constructorCall();
+        this.bar = 42;
+      }
+
+      @Query()
+      foo(): number {
+        return this.bar;
+      }
+    }
+
+    const schema = compileSchema({ roots: [FooSchema] });
+
+    const result = await graphql(
+      schema,
+      `
+        {
+          foo
+        }
+      `,
+    );
+
+    expect(constructorCall).toBeCalled();
+    expect(result.data.foo).toEqual(42);
+  });
 });


### PR DESCRIPTION
Now things like 

```ts
@SchemaRoot()
class FooSchema {
  private bar: number = 42;

  @Query()
  foo(): number {
    return this.bar;
  }
}
```

are possible.

This will allow Dependency Injection at schema root level