### PR TITLE
Duplex type

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -49,6 +49,32 @@ interface InputObjectTypeOptions {
 @InputField(options?: InputFieldOptions)
 ```
 
+### @DuplexObjectType
+
+```typescript
+interface DuplexObjectTypeOptions {
+  name?: string;
+  description?: string;
+}
+
+@DuplexObjectType(options?: DuplexObjectTypeOptions)
+```
+
+### @DuplexField
+
+```typescript
+ interface DuplexFieldOptions {
+  description?: string;
+  defaultValue?: any;
+  type?: any | () => any;
+  name?: string;
+  isNullable?: boolean;
+  inputNullable?: boolean;
+}
+
+@InputField(options?: InputFieldOptions)
+```
+
 ### @Arg
 
 ```typescript

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@types/graphql": "^0.13.0",
-    "@types/jest": "^22.2.3",
+    "@types/jest": "^23.0.0",
     "@types/node": "^10.1.2",
     "@types/object-path": "^0.9.29",
     "@zerollup/ts-transform-paths": "^1.1.2",
@@ -30,15 +30,15 @@
     "gitbook": "^3.2.3",
     "gitbook-cli": "^2.3.2",
     "husky": "^0.14.3",
-    "jest": "^23.0.0",
+    "jest": "^23.1.0",
     "prettier": "^1.12.1",
     "pretty-quick": "^1.6.0",
     "rimraf": "^2.6.2",
     "rollup": "^0.59.3",
     "rollup-plugin-typescript": "^0.8.1",
     "rollup-plugin-typescript2": "^0.11.1",
-    "ttypescript": "^1.2.0",
-    "typescript": "^2.8.1"
+    "ttypescript": "^1.4.6",
+    "typescript": "^2.9.1"
   },
   "dependencies": {
     "graphql": "^0.13.2",

--- a/src/domains/arg/compiler.ts
+++ b/src/domains/arg/compiler.ts
@@ -24,7 +24,7 @@ function compileInferedAndRegisterdArgs(
   });
 
   const resolvedArgs = argsMerged.map((rawType, index) => {
-    return resolveType(rawType);
+    return resolveType(rawType, true, true);
   });
 
   return resolvedArgs;
@@ -129,12 +129,10 @@ export function compileFieldArgs(
     target.prototype,
     fieldName,
   );
-
   // There are no arguments
   if (!inferedRawArgs) {
     return {};
   }
-
   const argTypes = compileInferedAndRegisterdArgs(
     inferedRawArgs,
     registeredArgs,

--- a/src/domains/duplexField/error.ts
+++ b/src/domains/duplexField/error.ts
@@ -1,0 +1,9 @@
+import { BaseError } from '~/services/error';
+
+export class FieldError extends BaseError {
+  constructor(target: Function, fieldName: string, msg: string) {
+    const fullMsg = `@DuplexField ${target.name}.${fieldName}: ${msg}`;
+    super(fullMsg);
+    this.message = fullMsg;
+  }
+}

--- a/src/domains/duplexField/index.ts
+++ b/src/domains/duplexField/index.ts
@@ -1,0 +1,50 @@
+import { fieldsRegistry, FieldInnerConfig } from '../field/registry';
+import {
+  inputFieldsRegistry,
+  FieldInputInnerConfig,
+} from '../inputField/registry';
+
+export { FieldError } from './error';
+
+export function DuplexField(
+  options?: FieldInnerConfig &
+    FieldInputInnerConfig & {
+      inputNullable?: boolean;
+    },
+): PropertyDecorator {
+  return (targetInstance: Object, fieldName: string) => {
+    let isNullable = true;
+    let inputNullable = true;
+    if (options) {
+      if (options.isNullable !== undefined) {
+        isNullable = options.isNullable;
+      }
+      if (options.inputNullable !== undefined) {
+        inputNullable = options.inputNullable;
+      }
+      delete options.isNullable;
+      delete options.inputNullable;
+    }
+
+    const finalInputConfig: FieldInputInnerConfig = {
+      property: fieldName,
+      name: fieldName,
+      isNullable: inputNullable,
+      ...options,
+    } as any;
+
+    const finalConfig: FieldInnerConfig = {
+      property: fieldName,
+      name: fieldName,
+      isNullable,
+      ...options,
+    } as any;
+    fieldsRegistry.set(targetInstance.constructor, fieldName, finalConfig);
+
+    inputFieldsRegistry.set(
+      targetInstance.constructor,
+      fieldName,
+      finalInputConfig,
+    );
+  };
+}

--- a/src/domains/duplexObjectType/error.ts
+++ b/src/domains/duplexObjectType/error.ts
@@ -1,0 +1,9 @@
+import { BaseError } from '~/services/error';
+
+export class ObjectTypeError extends BaseError {
+  constructor(target: Function, msg: string) {
+    const fullMsg = `@DuplexObjectType '${target.name}': ${msg}`;
+    super(fullMsg);
+    this.message = fullMsg;
+  }
+}

--- a/src/domains/duplexObjectType/index.ts
+++ b/src/domains/duplexObjectType/index.ts
@@ -1,0 +1,26 @@
+import { objectTypeRegistry } from '../objectType/registry';
+import { compileObjectTypeWithConfig } from '../objectType/compiler';
+import { compileInputObjectTypeWithConfig } from '../inputObjectType/compiler';
+import { inputObjectTypeRegistry } from '../inputObjectType/registry';
+export { ObjectTypeError } from './error';
+
+export interface ObjectTypeOptions {
+  name?: string;
+  description?: string;
+}
+
+export function DuplexObjectType(options?: ObjectTypeOptions): ClassDecorator {
+  return (target: Function) => {
+    const inputConfig = { name: target.name + 'Input', ...options };
+    const outputConfig = { name: target.name, ...options };
+
+    const inputTypeCompiler = () =>
+      compileInputObjectTypeWithConfig(target, inputConfig);
+
+    inputObjectTypeRegistry.set(target, inputTypeCompiler);
+
+    const outputTypeCompiler = () =>
+      compileObjectTypeWithConfig(target, outputConfig);
+    objectTypeRegistry.set(target, outputTypeCompiler);
+  };
+}

--- a/src/domains/field/compiler/index.ts
+++ b/src/domains/field/compiler/index.ts
@@ -72,5 +72,6 @@ export function compileAllFields(target: Function) {
   targetWithParents.forEach(targetLevel => {
     Object.assign(finalFieldsMap, getAllFields(targetLevel));
   });
+
   return finalFieldsMap;
 }

--- a/src/domains/field/compiler/services.ts
+++ b/src/domains/field/compiler/services.ts
@@ -33,7 +33,7 @@ export function validateResolvedType(
     throw new FieldError(
       target,
       fieldName,
-      `Validation of type failed. Resolved type for @Field must be GraphQLOutputType.`,
+      `Validation of type failed. Resolved type must be a GraphQLOutputType.`,
     );
   }
   return true;

--- a/src/domains/index.ts
+++ b/src/domains/index.ts
@@ -8,8 +8,10 @@ export {
   compileInputObjectType,
   inputObjectTypeRegistry,
 } from './inputObjectType';
+export { DuplexObjectType } from './duplexObjectType';
 export { Field } from './field';
 export { InputField } from './inputField';
+export { DuplexField } from './duplexField';
 export { Arg } from './arg';
 export { Inject, Context, Source, Info } from './inject';
 export { registerEnum, enumsRegistry } from './enum';

--- a/src/domains/inputField/compiler/fieldType.ts
+++ b/src/domains/inputField/compiler/fieldType.ts
@@ -9,7 +9,7 @@ export function resolveTypeOrThrow(
   target: Function,
   fieldName: string,
 ): GraphQLType {
-  const resolvedType = resolveType(type);
+  const resolvedType = resolveType(type, true, true);
 
   if (!resolvedType) {
     throw new InputFieldError(
@@ -27,6 +27,7 @@ export function inferTypeOrThrow(
   fieldName: string,
 ): GraphQLType {
   const inferedType = inferTypeByTarget(target.prototype, fieldName);
+
   if (!inferedType) {
     throw new InputFieldError(
       target,
@@ -34,5 +35,5 @@ export function inferTypeOrThrow(
       `Could not infer return type and no type is forced. In case of circular dependencies make sure to force types of instead of infering them.`,
     );
   }
-  return resolveType(inferedType);
+  return resolveType(inferedType, true, true);
 }

--- a/src/domains/inputField/compiler/index.ts
+++ b/src/domains/inputField/compiler/index.ts
@@ -31,7 +31,7 @@ function validateResolvedType(
     throw new InputFieldError(
       target,
       fieldName,
-      `Validation of type failed. Resolved type for @Field must be GraphQLInputType.`,
+      `Validation of type failed. Resolved type must be a GraphQLInputType.`,
     );
   }
   return true;

--- a/src/domains/inputObjectType/compiler/objectType.ts
+++ b/src/domains/inputObjectType/compiler/objectType.ts
@@ -44,7 +44,6 @@ export function compileInputObjectTypeWithConfig(
   if (compileOutputTypeCache.has(target)) {
     return compileOutputTypeCache.get(target);
   }
-
   const compiled = new GraphQLInputObjectType({
     ...config,
     fields: createTypeInputFieldsGetter(target),

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ export {
   SchemaRoot,
   Context,
   ObjectType,
+  DuplexObjectType,
+  DuplexField,
   Query,
   Mutation,
   InputField,

--- a/src/test/field/__snapshots__/index.spec.ts.snap
+++ b/src/test/field/__snapshots__/index.spec.ts.snap
@@ -6,4 +6,4 @@ exports[`Field Shows proper error message when trying to use promise type withou
 
 exports[`Field Throws if pointing to unregistered type 1`] = `"@ObjectType Bar.foo: Forced type is incorrect. Make sure to use either native graphql type or class that is registered with @Type decorator"`;
 
-exports[`Field Will not allow promise field without type addnotation 1`] = `"@ObjectType Foo.bar: It was not possible to guess type of this field. It might be because it returns Promise, Array etc. In such case it's needed to explicitly declare type of field like: @Field({ type: ItemType })"`;
+exports[`Field Will not allow promise field without type addnotation 1`] = `"@ObjectType Foo.bar: Field returns Promise so it's required to explicitly set resolved type as it's not possible to guess it. You can set resolved type like: @Field({ type: ItemType })"`;

--- a/src/test/functional/duplex.spec.ts
+++ b/src/test/functional/duplex.spec.ts
@@ -1,0 +1,68 @@
+import {
+  Query,
+  SchemaRoot,
+  compileSchema,
+  DuplexObjectType,
+  DuplexField,
+} from '~/domains';
+import { graphql } from 'graphql';
+
+describe('duplex object type', () => {
+  it('should compile and work', async () => {
+    @DuplexObjectType()
+    class SecondDuplex {
+      constructor(foo: string) {
+        this.foo2 = foo;
+      }
+      @DuplexField() foo2: string;
+    }
+
+    @DuplexObjectType()
+    class Duplex {
+      constructor(foo: string) {
+        this.foo = foo;
+      }
+      @DuplexField() foo: string;
+      @DuplexField() fod: SecondDuplex;
+    }
+
+    @SchemaRoot()
+    class FooSchema {
+      @Query()
+      output(): SecondDuplex {
+        return new SecondDuplex('bar');
+      }
+      @Query()
+      echo(input: Duplex): Duplex {
+        expect(input.fod.foo2).toBe('bbb');
+        return new Duplex(input.foo);
+      }
+    }
+    const schema = compileSchema({ roots: [FooSchema] });
+    const result = await graphql(
+      schema,
+      `
+        {
+          output {
+            foo2
+          }
+        }
+      `,
+    );
+
+    expect(result).toEqual({ data: { output: { foo2: 'bar' } } });
+
+    const result2 = await graphql(
+      schema,
+      `
+        {
+          echo(input: { foo: "aaa", fod: { foo2: "bbb" } }) {
+            foo
+          }
+        }
+      `,
+    );
+
+    expect(result2).toEqual({ data: { echo: { foo: 'aaa' } } });
+  });
+});

--- a/src/test/schema/__snapshots__/index.spec.ts.snap
+++ b/src/test/schema/__snapshots__/index.spec.ts.snap
@@ -1019,4 +1019,4 @@ exports[`@SchemaRoot should not allow schema that has only mutation fields 1`] =
 
 exports[`@SchemaRoot will not allow multiple schema roots to have conflicting root field names 1`] = `"@Schema BarSchema: Duplicate of root field name: 'foo'. Seems this name is also used inside other schema root."`;
 
-exports[`@SchemaRoot will not allow schema with incorrect object types 1`] = `"@ObjectType Hello.world: It was not possible to guess type of this field. It might be because it returns Promise, Array etc. In such case it's needed to explicitly declare type of field like: @Field({ type: ItemType })"`;
+exports[`@SchemaRoot will not allow schema with incorrect object types 1`] = `"@ObjectType Hello.world: Field returns Promise so it's required to explicitly set resolved type as it's not possible to guess it. You can set resolved type like: @Field({ type: ItemType })"`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,9 +24,9 @@
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.13.0.tgz#78a33a7f429a06a64714817d9130d578e0f35ecb"
 
-"@types/jest@^22.2.3":
-  version "22.2.3"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-22.2.3.tgz#0157c0316dc3722c43a7b71de3fdf3acbccef10d"
+"@types/jest@^23.0.0":
+  version "23.0.0"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.0.0.tgz#760cac74f00bb9c3075587716d2b3b4435663bc0"
 
 "@types/node@*":
   version "9.6.5"
@@ -417,12 +417,12 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-jest@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.0.0.tgz#0e383a2aa6b3535e197db2929570a2182bd084e8"
+babel-jest@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.0.1.tgz#bbad3bf523fb202da05ed0a6540b48c84eed13a6"
   dependencies:
     babel-plugin-istanbul "^4.1.6"
-    babel-preset-jest "^23.0.0"
+    babel-preset-jest "^23.0.1"
 
 babel-messages@^6.23.0:
   version "6.23.0"
@@ -439,19 +439,19 @@ babel-plugin-istanbul@^4.1.6:
     istanbul-lib-instrument "^1.10.1"
     test-exclude "^4.2.1"
 
-babel-plugin-jest-hoist@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.0.0.tgz#e61e68799f743391a1e6306ee270477aacf946c8"
+babel-plugin-jest-hoist@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.0.1.tgz#eaa11c964563aea9c21becef2bdf7853f7f3c148"
 
 babel-plugin-syntax-object-rest-spread@^6.13.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
-babel-preset-jest@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.0.0.tgz#49de0303f1b6875dcad6163eaa7eb8330d54824d"
+babel-preset-jest@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.0.1.tgz#631cc545c6cf021943013bcaf22f45d87fe62198"
   dependencies:
-    babel-plugin-jest-hoist "^23.0.0"
+    babel-plugin-jest-hoist "^23.0.1"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
 babel-register@^6.26.0:
@@ -1638,15 +1638,15 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-expect@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-23.0.0.tgz#2c3ab0a44dae319e00a73e3561762768d03a2b27"
+expect@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-23.1.0.tgz#bfdfd57a2a20170d875999ee9787cc71f01c205f"
   dependencies:
     ansi-styles "^3.2.0"
-    jest-diff "^23.0.0"
+    jest-diff "^23.0.1"
     jest-get-type "^22.1.0"
-    jest-matcher-utils "^23.0.0"
-    jest-message-util "^23.0.0"
+    jest-matcher-utils "^23.0.1"
+    jest-message-util "^23.1.0"
     jest-regex-util "^23.0.0"
 
 extend-shallow@^2.0.1:
@@ -2960,15 +2960,15 @@ iterall@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
 
-jest-changed-files@^22.2.0:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-22.4.3.tgz#8882181e022c38bd46a2e4d18d44d19d90a90fb2"
+jest-changed-files@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-23.0.1.tgz#f79572d0720844ea5df84c2a448e862c2254f60c"
   dependencies:
     throat "^4.0.0"
 
-jest-cli@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-23.0.0.tgz#29287498c9d844dcda5aaf011a4c82f9a888836e"
+jest-cli@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-23.1.0.tgz#eb8bdd4ce0d15250892e31ad9b69bc99d2a8f6bf"
   dependencies:
     ansi-escapes "^3.0.0"
     chalk "^2.0.1"
@@ -2981,20 +2981,21 @@ jest-cli@^23.0.0:
     istanbul-lib-coverage "^1.2.0"
     istanbul-lib-instrument "^1.10.1"
     istanbul-lib-source-maps "^1.2.4"
-    jest-changed-files "^22.2.0"
-    jest-config "^23.0.0"
-    jest-environment-jsdom "^23.0.0"
+    jest-changed-files "^23.0.1"
+    jest-config "^23.1.0"
+    jest-environment-jsdom "^23.1.0"
     jest-get-type "^22.1.0"
-    jest-haste-map "^23.0.0"
-    jest-message-util "^23.0.0"
+    jest-haste-map "^23.1.0"
+    jest-message-util "^23.1.0"
     jest-regex-util "^23.0.0"
-    jest-resolve-dependencies "^23.0.0"
-    jest-runner "^23.0.0"
-    jest-runtime "^23.0.0"
-    jest-snapshot "^23.0.0"
-    jest-util "^23.0.0"
-    jest-validate "^23.0.0"
-    jest-worker "^23.0.0"
+    jest-resolve-dependencies "^23.0.1"
+    jest-runner "^23.1.0"
+    jest-runtime "^23.1.0"
+    jest-snapshot "^23.0.1"
+    jest-util "^23.1.0"
+    jest-validate "^23.0.1"
+    jest-watcher "^23.1.0"
+    jest-worker "^23.0.1"
     micromatch "^2.3.11"
     node-notifier "^5.2.1"
     realpath-native "^1.0.0"
@@ -3005,102 +3006,110 @@ jest-cli@^23.0.0:
     which "^1.2.12"
     yargs "^11.0.0"
 
-jest-config@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-23.0.0.tgz#9444d858873ad567376f8cfe139fd8828e8d494b"
+jest-config@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-23.1.0.tgz#708ca0f431d356ee424fb4895d3308006bdd8241"
   dependencies:
     babel-core "^6.0.0"
-    babel-jest "^23.0.0"
+    babel-jest "^23.0.1"
     chalk "^2.0.1"
     glob "^7.1.1"
-    jest-environment-jsdom "^23.0.0"
-    jest-environment-node "^23.0.0"
+    jest-environment-jsdom "^23.1.0"
+    jest-environment-node "^23.1.0"
     jest-get-type "^22.1.0"
-    jest-jasmine2 "^23.0.0"
+    jest-jasmine2 "^23.1.0"
     jest-regex-util "^23.0.0"
-    jest-resolve "^23.0.0"
-    jest-util "^23.0.0"
-    jest-validate "^23.0.0"
-    pretty-format "^23.0.0"
+    jest-resolve "^23.1.0"
+    jest-util "^23.1.0"
+    jest-validate "^23.0.1"
+    pretty-format "^23.0.1"
 
-jest-diff@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.0.0.tgz#0a00b2157f518eec338121ccf8879c529269a88e"
+jest-diff@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.0.1.tgz#3d49137cee12c320a4b4d2b4a6fa6e82d491a16a"
   dependencies:
     chalk "^2.0.1"
     diff "^3.2.0"
     jest-get-type "^22.1.0"
-    pretty-format "^23.0.0"
+    pretty-format "^23.0.1"
 
-jest-docblock@^22.4.0:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-22.4.3.tgz#50886f132b42b280c903c592373bb6e93bb68b19"
+jest-docblock@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-23.0.1.tgz#deddd18333be5dc2415260a04ef3fce9276b5725"
   dependencies:
     detect-newline "^2.1.0"
 
-jest-environment-jsdom@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-23.0.0.tgz#57b0f0dd263359a86d7952a4b712b3fabca1a625"
+jest-each@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-23.1.0.tgz#16146b592c354867a5ae5e13cdf15c6c65b696c6"
   dependencies:
-    jest-mock "^23.0.0"
-    jest-util "^23.0.0"
+    chalk "^2.0.1"
+    pretty-format "^23.0.1"
+
+jest-environment-jsdom@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-23.1.0.tgz#85929914e23bed3577dac9755f4106d0697c479c"
+  dependencies:
+    jest-mock "^23.1.0"
+    jest-util "^23.1.0"
     jsdom "^11.5.1"
 
-jest-environment-node@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-23.0.0.tgz#ef93a414a612484cf585c8b32ccc5ae30ce6095c"
+jest-environment-node@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-23.1.0.tgz#452c0bf949cfcbbacda1e1762eeed70bc784c7d5"
   dependencies:
-    jest-mock "^23.0.0"
-    jest-util "^23.0.0"
+    jest-mock "^23.1.0"
+    jest-util "^23.1.0"
 
 jest-get-type@^22.1.0:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
 
-jest-haste-map@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-23.0.0.tgz#09be1c9a37c16b2e2f25398864eb2806d309ca96"
+jest-haste-map@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-23.1.0.tgz#18e6c7d5a8d27136f91b7d9852f85de0c7074c49"
   dependencies:
     fb-watchman "^2.0.0"
     graceful-fs "^4.1.11"
-    jest-docblock "^22.4.0"
-    jest-serializer "^23.0.0"
-    jest-worker "^23.0.0"
+    jest-docblock "^23.0.1"
+    jest-serializer "^23.0.1"
+    jest-worker "^23.0.1"
     micromatch "^2.3.11"
     sane "^2.0.0"
 
-jest-jasmine2@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-23.0.0.tgz#ea26f87b5c223e1a70985032f0727d8f855e59df"
+jest-jasmine2@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-23.1.0.tgz#4afab31729b654ddcd2b074add849396f13b30b8"
   dependencies:
     chalk "^2.0.1"
     co "^4.6.0"
-    expect "^23.0.0"
+    expect "^23.1.0"
     is-generator-fn "^1.0.0"
-    jest-diff "^23.0.0"
-    jest-matcher-utils "^23.0.0"
-    jest-message-util "^23.0.0"
-    jest-snapshot "^23.0.0"
-    jest-util "^23.0.0"
-    pretty-format "^23.0.0"
+    jest-diff "^23.0.1"
+    jest-each "^23.1.0"
+    jest-matcher-utils "^23.0.1"
+    jest-message-util "^23.1.0"
+    jest-snapshot "^23.0.1"
+    jest-util "^23.1.0"
+    pretty-format "^23.0.1"
 
-jest-leak-detector@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-23.0.0.tgz#ec93d755b21e8b2c4c4e59b8cccab1805a704ab3"
+jest-leak-detector@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-23.0.1.tgz#9dba07505ac3495c39d3ec09ac1e564599e861a0"
   dependencies:
-    pretty-format "^23.0.0"
+    pretty-format "^23.0.1"
 
-jest-matcher-utils@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-23.0.0.tgz#ca2168fe5a7a416c0d7f2916e969e89dcce9d92a"
+jest-matcher-utils@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-23.0.1.tgz#0c6c0daedf9833c2a7f36236069efecb4c3f6e5f"
   dependencies:
     chalk "^2.0.1"
     jest-get-type "^22.1.0"
-    pretty-format "^23.0.0"
+    pretty-format "^23.0.1"
 
-jest-message-util@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-23.0.0.tgz#073f3d76c701f7c718a4b9af1eb7f138792c4796"
+jest-message-util@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-23.1.0.tgz#9a809ba487ecac5ce511d4e698ee3b5ee2461ea9"
   dependencies:
     "@babel/code-frame" "^7.0.0-beta.35"
     chalk "^2.0.1"
@@ -3108,66 +3117,66 @@ jest-message-util@^23.0.0:
     slash "^1.0.0"
     stack-utils "^1.0.1"
 
-jest-mock@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.0.0.tgz#d9d897a1b74dc05c66a737213931496215897dd8"
+jest-mock@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.1.0.tgz#a381c31b121ab1f60c462a2dadb7b86dcccac487"
 
 jest-regex-util@^23.0.0:
   version "23.0.0"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-23.0.0.tgz#dd5c1fde0c46f4371314cf10f7a751a23f4e8f76"
 
-jest-resolve-dependencies@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-23.0.0.tgz#c3e1cfee0e543dee10e6ec0628df69cd239244c9"
+jest-resolve-dependencies@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-23.0.1.tgz#d01a10ddad9152c4cecdf5eac2b88571c4b6a64d"
   dependencies:
     jest-regex-util "^23.0.0"
-    jest-snapshot "^23.0.0"
+    jest-snapshot "^23.0.1"
 
-jest-resolve@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-23.0.0.tgz#f04362fd0531b4546399df76c55c3214a9f45e02"
+jest-resolve@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-23.1.0.tgz#b9e316eecebd6f00bc50a3960d1527bae65792d2"
   dependencies:
     browser-resolve "^1.11.2"
     chalk "^2.0.1"
     realpath-native "^1.0.0"
 
-jest-runner@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-23.0.0.tgz#b198a2dd78d57a2c0f3f8d7c7f97b62673922020"
+jest-runner@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-23.1.0.tgz#fa20a933fff731a5432b3561e7f6426594fa29b5"
   dependencies:
     exit "^0.1.2"
     graceful-fs "^4.1.11"
-    jest-config "^23.0.0"
-    jest-docblock "^22.4.0"
-    jest-haste-map "^23.0.0"
-    jest-jasmine2 "^23.0.0"
-    jest-leak-detector "^23.0.0"
-    jest-message-util "^23.0.0"
-    jest-runtime "^23.0.0"
-    jest-util "^23.0.0"
-    jest-worker "^23.0.0"
+    jest-config "^23.1.0"
+    jest-docblock "^23.0.1"
+    jest-haste-map "^23.1.0"
+    jest-jasmine2 "^23.1.0"
+    jest-leak-detector "^23.0.1"
+    jest-message-util "^23.1.0"
+    jest-runtime "^23.1.0"
+    jest-util "^23.1.0"
+    jest-worker "^23.0.1"
     source-map-support "^0.5.6"
     throat "^4.0.0"
 
-jest-runtime@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-23.0.0.tgz#8619227fe2e01603d542b9101dd3e64ef4593f66"
+jest-runtime@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-23.1.0.tgz#b4ae0e87259ecacfd4a884b639db07cf4dd620af"
   dependencies:
     babel-core "^6.0.0"
     babel-plugin-istanbul "^4.1.6"
     chalk "^2.0.1"
     convert-source-map "^1.4.0"
     exit "^0.1.2"
+    fast-json-stable-stringify "^2.0.0"
     graceful-fs "^4.1.11"
-    jest-config "^23.0.0"
-    jest-haste-map "^23.0.0"
-    jest-message-util "^23.0.0"
+    jest-config "^23.1.0"
+    jest-haste-map "^23.1.0"
+    jest-message-util "^23.1.0"
     jest-regex-util "^23.0.0"
-    jest-resolve "^23.0.0"
-    jest-snapshot "^23.0.0"
-    jest-util "^23.0.0"
-    jest-validate "^23.0.0"
-    json-stable-stringify "^1.0.1"
+    jest-resolve "^23.1.0"
+    jest-snapshot "^23.0.1"
+    jest-util "^23.1.0"
+    jest-validate "^23.0.1"
     micromatch "^2.3.11"
     realpath-native "^1.0.0"
     slash "^1.0.0"
@@ -3175,54 +3184,63 @@ jest-runtime@^23.0.0:
     write-file-atomic "^2.1.0"
     yargs "^11.0.0"
 
-jest-serializer@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-23.0.0.tgz#263411ac92e1e3dde243858642bb04e8a986e8ca"
+jest-serializer@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-23.0.1.tgz#a3776aeb311e90fe83fab9e533e85102bd164165"
 
-jest-snapshot@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-23.0.0.tgz#49cdb92a69b9999dbf92e0634d5ba1e8a8586803"
+jest-snapshot@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-23.0.1.tgz#6674fa19b9eb69a99cabecd415bddc42d6af3e7e"
   dependencies:
     chalk "^2.0.1"
-    jest-diff "^23.0.0"
-    jest-matcher-utils "^23.0.0"
+    jest-diff "^23.0.1"
+    jest-matcher-utils "^23.0.1"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
-    pretty-format "^23.0.0"
+    pretty-format "^23.0.1"
 
-jest-util@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-23.0.0.tgz#86386800ffbe3fe17a06320e0cf9ca9b7868263b"
+jest-util@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-23.1.0.tgz#c0251baf34644c6dd2fea78a962f4263ac55772d"
   dependencies:
     callsites "^2.0.0"
     chalk "^2.0.1"
     graceful-fs "^4.1.11"
     is-ci "^1.0.10"
-    jest-message-util "^23.0.0"
+    jest-message-util "^23.1.0"
     mkdirp "^0.5.1"
+    slash "^1.0.0"
     source-map "^0.6.0"
 
-jest-validate@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.0.0.tgz#f88bc897b6cc376979aff0262d1025df1302d520"
+jest-validate@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.0.1.tgz#cd9f01a89d26bb885f12a8667715e9c865a5754f"
   dependencies:
     chalk "^2.0.1"
     jest-get-type "^22.1.0"
     leven "^2.1.0"
-    pretty-format "^23.0.0"
+    pretty-format "^23.0.1"
 
-jest-worker@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-23.0.0.tgz#e6b1378b81f8e6a108f3be33a1faa830c22ea450"
+jest-watcher@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-23.1.0.tgz#a8d5842e38d9fb4afff823df6abb42a58ae6cdbd"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.1"
+    string-length "^2.0.0"
+
+jest-worker@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-23.0.1.tgz#9e649dd963ff4046026f91c4017f039a6aa4a7bc"
   dependencies:
     merge-stream "^1.0.1"
 
-jest@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-23.0.0.tgz#9282980309f5cde27aadc59ae583f1117c0e4430"
+jest@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-23.1.0.tgz#bbb7f893100a11a742dd8bd0d047a54b0968ad1a"
   dependencies:
     import-local "^1.0.0"
-    jest-cli "^23.0.0"
+    jest-cli "^23.1.0"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -4894,9 +4912,9 @@ prettier@^1.12.1:
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.12.1.tgz#c1ad20e803e7749faf905a409d2367e06bbe7325"
 
-pretty-format@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.0.0.tgz#b66dc584a0907b1969783c4c20e4d1180b18ac75"
+pretty-format@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.0.1.tgz#d61d065268e4c759083bccbca27a01ad7c7601f4"
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
@@ -6196,12 +6214,13 @@ tslib@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
 
-ttypescript@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ttypescript/-/ttypescript-1.2.0.tgz#cacf507749b89cf783f992ae582233db6907a2ae"
+ttypescript@^1.4.6:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/ttypescript/-/ttypescript-1.4.6.tgz#d719c4272f842b05b4ad66fd0ec57af0b8be6eb0"
   dependencies:
     resolve "^1.7.1"
     ts-node "^6.0.2"
+    typescript ">=2.7.0"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -6234,13 +6253,13 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+typescript@>=2.7.0, typescript@^2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.1.tgz#fdb19d2c67a15d11995fd15640e373e09ab09961"
+
 typescript@^1.8.9:
   version "1.8.10"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-1.8.10.tgz#b475d6e0dff0bf50f296e5ca6ef9fbb5c7320f1e"
-
-typescript@^2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.1.tgz#6160e4f8f195d5ba81d4876f9c0cc1fbc0820624"
 
 uglify-js@^2.4.1, uglify-js@^2.6:
   version "2.8.29"


### PR DESCRIPTION
I know you've said that you don't want to implement a Duplex type, but I'd like you to reconsider. GraphQL spec has good reasons not to do this-GraphQL raw schemas are mostly meant for consumption by machines. Explicitness and some repetition is perfectly fine there.

But in our code that we humans write and read this verbose explicit code is not always so great. We shouldn't force everyone to follow graphql spec in their own programming language. This library's API is not bound by the graphql spec. It's output is bound by it, but not it's client API. Making it easier to write a graphql API is what this library is all about for me. The minority of users of this lib who would want to define separate input and object types still can. 

I've implemented just a simple POC which might still have some uncovered bugs, but I think it demostrates clearly that it's easily achieved.