### PR TITLE
Implement defaultValue for @Arg

### DIFF
--- a/src/domains/arg/compiler.ts
+++ b/src/domains/arg/compiler.ts
@@ -114,6 +114,7 @@ function convertArgsArrayToArgsMap(
     argsMap[argName] = {
       type: finalType,
       description: argConfig.description,
+      defaultValue: argConfig.defaultValue,
     };
   });
   return argsMap;

--- a/src/domains/arg/options.ts
+++ b/src/domains/arg/options.ts
@@ -2,6 +2,7 @@ export interface ArgOptions {
   description?: string;
   type?: any;
   isNullable?: boolean;
+  defaultValue?: any;
 }
 
 export const defaultArgOptions: ArgOptions = {

--- a/src/domains/arg/registry.ts
+++ b/src/domains/arg/registry.ts
@@ -4,6 +4,7 @@ export interface ArgInnerConfig {
   description?: string;
   isNullable?: boolean;
   type?: any;
+  defaultValue?: any;
 }
 
 export const argRegistry = new DeepWeakMap<

--- a/src/test/arg/basics.spec.ts
+++ b/src/test/arg/basics.spec.ts
@@ -94,16 +94,13 @@ describe('Arguments with @Arg', () => {
     @ObjectType()
     class Foo {
       @Field()
-      bar(
-        baz: string,
-        bazRequired: string,
-      ): string {
+      bar(baz: string, bazRequired: string): string {
         return baz;
       }
     }
 
-    Arg({type: String, isNullable: true})(Foo.prototype, 'bar', 0);
-    Arg({type: String, isNullable: false})(Foo.prototype, 'bar', 1);
+    Arg({ type: String, isNullable: true })(Foo.prototype, 'bar', 0);
+    Arg({ type: String, isNullable: false })(Foo.prototype, 'bar', 1);
 
     const [bazArg, bazRequiredArg] = compileObjectType(
       Foo,
@@ -111,5 +108,43 @@ describe('Arguments with @Arg', () => {
 
     expect(bazArg.type).toBe(GraphQLString);
     expect(bazRequiredArg.type).toEqual(new GraphQLNonNull(GraphQLString));
+  });
+
+  it('Respects unset defaultValue @Arg option', () => {
+    @ObjectType()
+    class Foo {
+      @Field()
+      bar(
+        @Arg({ isNullable: true })
+        baz: string,
+        @Arg({ isNullable: false })
+        bazRequired: string,
+      ): string {
+        return baz;
+      }
+    }
+    const [bazArg, bazRequiredArg] = compileObjectType(
+      Foo,
+    ).getFields().bar.args;
+    expect(bazArg.type).toBe(GraphQLString);
+    expect(bazArg.defaultValue).toBe(undefined);
+    expect(bazRequiredArg.type).toEqual(new GraphQLNonNull(GraphQLString));
+  });
+
+  it('Respects defaultValue @Arg option', () => {
+    @ObjectType()
+    class Foo {
+      @Field()
+      bar(
+        @Arg({ isNullable: true, defaultValue: 'default' })
+        baz: string,
+      ): string {
+        return baz;
+      }
+    }
+    const compiledObject = compileObjectType(Foo);
+    const [bazArg] = compiledObject.getFields().bar.args;
+    expect(bazArg.type).toBe(GraphQLString);
+    expect(bazArg.defaultValue).toBe('default');
   });
 });


### PR DESCRIPTION
Found reference to having defaultValue defined in the docs, but it isn't actually in the code (and I thought it'd be good to use).

I figured it should be fairly straightforward to implement, so I've had a go. The only thing I'm not clear about is whether having a defaultValue defined means the type is nullable? I think they are independent still, so I've left isNullable alone.

Hopefully I haven't missed anything, I haven't made an effort to try and understand the whole codebase, just the bits I was interested in.