### PR TITLE
correct the @After hook example

### DIFF
--- a/docs/explore/hooks/before-and-after.md
+++ b/docs/explore/hooks/before-and-after.md
@@ -34,10 +34,8 @@ class Person {
   @Field() id: number;
 
   @Field()
-  @After(user => {
-    loggingService.sendLog(`User with id ${user.id} was removed`);
-    // note we could as well use `this` keyword like:
-    // loggingService.sendLog(`User with id ${this.id} was removed`);
+  @After(() => {
+    loggingService.sendLog(`User with id ${this.id} may have been removed(if it was found)`); 
   })
   remove(): boolean {
     const isDeleted = userService.removeById(this.id);


### PR DESCRIPTION
as it was before it was a bit confusing.

This example would have worked much better if the TODO left in code about passing the return value was implemented.
Then it could be something like:

![image](https://user-images.githubusercontent.com/1305378/56283929-592e7300-6113-11e9-82a4-6c48ff2ff6cd.png)
